### PR TITLE
set log level trace

### DIFF
--- a/CustomTV/TVIntercept.cs
+++ b/CustomTV/TVIntercept.cs
@@ -209,7 +209,7 @@ namespace CustomTV
         {
             
             string a = answer.Split(' ')[0];
-            CustomTVMod.monitor.Log("Select Channel:"+a);
+            CustomTVMod.monitor.Log("Select Channel:"+a,LogLevel.Trace);
           
             if (a == "more")
             {


### PR DESCRIPTION
The debug logs don't need to appear in the console output. That is for more prominent errors. This is better as a Trace level logs. (Only appears in the SMAPI-latest.txt log)