### PR TITLE
Add machine info to Custom Farming Redux API

### DIFF
--- a/CustomFarmingRedux/CustomFarmingReduxAPI.cs
+++ b/CustomFarmingRedux/CustomFarmingReduxAPI.cs
@@ -1,9 +1,9 @@
-﻿using Microsoft.Xna.Framework.Graphics;
+﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
 using PyTK.Extensions;
 using PyTK.Types;
 using StardewModdingAPI;
 using StardewValley;
-using System;
 using System.Collections.Generic;
 using System.IO;
 
@@ -26,7 +26,48 @@ namespace CustomFarmingRedux
             return machine;
         }
 
-        public void addContentPack(string folderName, string fileName, IModHelper helper = null, Dictionary<string,string> options = null)
+        /// <summary>Get whether a given item is a custom object or machine from Custom Farming Redux.</summary>
+        /// <param name="item">The item instance.</param>
+        public bool isCustom(Item item)
+        {
+            return item is CustomMachine || item is CustomObject;
+        }
+
+        /// <summary>Get the spritesheet texture for a custom object or machine (if applicable).</summary>
+        /// <param name="item">The item instance.</param>
+        public Texture2D getSpritesheet(Item item)
+        {
+            switch (item)
+            {
+                case CustomMachine machine:
+                    return machine.texture;
+
+                case CustomObject obj:
+                    return obj.texture;
+
+                default:
+                    return null;
+            }
+        }
+
+        /// <summary>Get the spritesheet source area for a custom object or machine (if applicable).</summary>
+        /// <param name="item">The item instance.</param>
+        public Rectangle? getSpriteSourceArea(Item item)
+        {
+            switch (item)
+            {
+                case CustomMachine machine:
+                    return machine.sourceRectangle;
+
+                case CustomObject obj:
+                    return obj.sourceRectangle;
+
+                default:
+                    return null;
+            }
+        }
+
+        public void addContentPack(string folderName, string fileName, IModHelper helper = null, Dictionary<string, string> options = null)
         {
             if (helper == null)
                 helper = Helper;

--- a/CustomFarmingRedux/CustomMachine.cs
+++ b/CustomFarmingRedux/CustomMachine.cs
@@ -22,16 +22,11 @@ namespace CustomFarmingRedux
         internal string folder => blueprint.pack.baseFolder;
         internal List<CustomMachineBlueprint> machines = CustomFarmingReduxMod.machines;
         internal static List<CustomMachine> activeMachines = new List<CustomMachine>();
+        internal Texture2D texture { get; private set; }
+        internal Rectangle sourceRectangle => Game1.getSourceRectForStandardTileSheet(texture, blueprint.tileindex + frame, tilesize.Width, tilesize.Height);
 
         private CustomMachineBlueprint blueprint;
 
-        private Texture2D texture;
-        private Rectangle sourceRectangle {
-            get
-            {
-               return Game1.getSourceRectForStandardTileSheet(texture, blueprint.tileindex + frame, tilesize.Width, tilesize.Height);
-            }
-        }
         private bool active = true;
         private bool wasBuild = false;
         private bool isWorking { get => active && !readyForHarvest && ((completionTime != null && activeRecipe != null) || blueprint.production == null); }
@@ -195,7 +190,7 @@ namespace CustomFarmingRedux
                         if (location.objects.ContainsKey(tile) && location.objects[tile] is Chest c)
                             items.AddOrReplace(c.items);
             }
-            
+
             return items;
         }
 
@@ -287,7 +282,7 @@ namespace CustomFarmingRedux
 
             if (isWorking && completionTime != null && STime.CURRENT >= completionTime && activeRecipe != null)
                 getReadyForHarvest();
-            
+
             if (!(isWorking && completionTime != null))
                 startAutoProduction();
 
@@ -451,7 +446,7 @@ namespace CustomFarmingRedux
 
         public override bool checkForAction(SFarmer who, bool justCheckingForActivity = false)
         {
-            
+
             if (blueprint.category == "Mailbox")
             {
                 if (justCheckingForActivity)
@@ -471,7 +466,7 @@ namespace CustomFarmingRedux
             {
                 if (justCheckingForActivity)
                     return true;
-                
+
                 shakeTimer = 100;
 
                 if (specialVariable == 0)
@@ -486,7 +481,7 @@ namespace CustomFarmingRedux
 
             if (heldObject == null)
                 return (who.ActiveObject is SObject o && findRecipe(maxed(o)) != null && hasStarterMaterials(who.items));
-                
+
             if (!readyForHarvest)
                 return false;
 
@@ -555,10 +550,10 @@ namespace CustomFarmingRedux
             bool hasStarter = hasStarterMaterials(items);
             bool hasIngredients = hasRecipe && recipe.hasIngredients(items);
             bool canProduce = hasIngredients && hasStarter;
-            
+
             if (probe)
                 return canProduce;
-            
+
             if (canProduce)
             {
                 startProduction(dropIn, findRecipeFor(maxed(dropIn)), items);


### PR DESCRIPTION
This pull request adds three methods to the Custom Farming Redux API:
```cs
/// <summary>Get whether a given item is a custom object or machine from Custom Farming Redux.</summary>
/// <param name="item">The item instance.</param>
bool isCustom(Item item);

/// <summary>Get the spritesheet texture for a custom object or machine (if applicable).</summary>
/// <param name="item">The item instance.</param>
Texture2D getSpritesheet(Item item);

/// <summary>Get the spritesheet source area for a custom object or machine (if applicable).</summary>
/// <param name="item">The item instance.</param>
Rectangle? getSpriteSourceArea(Item item);
```

Lookup Anything uses these to support lookups on custom objects in the upcoming release. The `getSpritesheet` and `getSpriteSourceArea` are needed for pixel collision checks; for example, pressing `F1` here would show what's behind the machine:
> ![](https://user-images.githubusercontent.com/230581/36125038-6c6ce432-1020-11e8-9e75-322ed354d8ad.png)

Here's an example of what Lookup Anything will show for a custom machine:
> ![](https://user-images.githubusercontent.com/230581/36124964-2099a78e-1020-11e8-81df-8bc7f4f46d68.png)