### PR TITLE
Initial changes for Stardew Valley 1.3

### DIFF
--- a/Arcade2048/Arcade2048.csproj
+++ b/Arcade2048/Arcade2048.csproj
@@ -11,8 +11,6 @@
     <AssemblyName>Arcade2048</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -33,12 +31,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
@@ -60,19 +52,19 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <Analyzer Include="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-alpha20180410\analyzers\dotnet\cs\StardewModdingAPI.ModBuildConfig.Analyzer.dll" />
-  </ItemGroup>
-  <ItemGroup>
     <Content Include="Assets\arcade.png">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\analyzers\dotnet\cs\StardewModdingAPI.ModBuildConfig.Analyzer.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-alpha20180410\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-alpha20180410\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
+  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-alpha20180410\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-alpha20180410\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
+    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
   </Target>
 </Project>

--- a/Arcade2048/manifest.json
+++ b/Arcade2048/manifest.json
@@ -1,15 +1,11 @@
 {
   "Name": "Arcade 2048",
   "Author": "Platonymous",
-  "Version": {
-    "MajorVersion": 1,
-    "MinorVersion": 0,
-    "PatchVersion": 0,
-    "Build": null
-  },
+  "Version": "1.0.0",
   "Description": "Play 2048.",
   "UniqueID": "Platonymous.2048",
   "EntryDll": "Arcade2048.dll",
+  "MinimumApiVersion": "2.6-beta",
   "UpdateKeys": [ "Nexus:2048" ],
   "Dependencies": [
     {

--- a/Arcade2048/packages.config
+++ b/Arcade2048/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.1.0-alpha20180410" targetFramework="net45" />
+  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.1.0-beta-20180426" targetFramework="net45" />
 </packages>

--- a/ArcadePong/ArcadePong.csproj
+++ b/ArcadePong/ArcadePong.csproj
@@ -11,8 +11,6 @@
     <AssemblyName>ArcadePong</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -33,12 +31,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
@@ -52,9 +44,6 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <Analyzer Include="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-alpha20180410\analyzers\dotnet\cs\StardewModdingAPI.ModBuildConfig.Analyzer.dll" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\..\Harmony\Harmony\Harmony.csproj">
       <Project>{69aee16a-b6e7-4642-8081-3928b32455df}</Project>
       <Name>Harmony</Name>
@@ -66,12 +55,15 @@
       <Private>False</Private>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\analyzers\dotnet\cs\StardewModdingAPI.ModBuildConfig.Analyzer.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-alpha20180410\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-alpha20180410\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
+  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-alpha20180410\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-alpha20180410\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
+    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
   </Target>
 </Project>

--- a/ArcadePong/manifest.json
+++ b/ArcadePong/manifest.json
@@ -1,15 +1,11 @@
 {
   "Name": "Arcade Pong",
   "Author": "Platonymous",
-  "Version": {
-    "MajorVersion": 1,
-    "MinorVersion": 0,
-    "PatchVersion": 0,
-    "Build": null
-  },
+  "Version": "1.0.0",
   "Description": "Takes Cat's Pong and puts it where it belongs.",
   "UniqueID": "Platonymous.ArcadePong",
   "EntryDll": "ArcadePong.dll",
+  "MinimumApiVersion": "2.6-beta",
   "UpdateKeys": [ "Nexus:2044" ],
   "Dependencies": [
     {

--- a/ArcadePong/manifest.json
+++ b/ArcadePong/manifest.json
@@ -10,6 +10,7 @@
   "Description": "Takes Cat's Pong and puts it where it belongs.",
   "UniqueID": "Platonymous.ArcadePong",
   "EntryDll": "ArcadePong.dll",
+  "UpdateKeys": [ "Nexus:2044" ],
   "Dependencies": [
     {
       "UniqueID": "cat.Pong"

--- a/ArcadePong/packages.config
+++ b/ArcadePong/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.1.0-alpha20180410" targetFramework="net45" />
+  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.1.0-beta-20180426" targetFramework="net45" />
 </packages>

--- a/CFAutomate/CFAutomate.csproj
+++ b/CFAutomate/CFAutomate.csproj
@@ -56,13 +56,16 @@
     <None Include="manifest.json" />
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\analyzers\dotnet\cs\StardewModdingAPI.ModBuildConfig.Analyzer.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\deploy-mod.targets" />
-  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
+  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
+    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
   </Target>
 </Project>

--- a/CFAutomate/manifest.json
+++ b/CFAutomate/manifest.json
@@ -1,15 +1,12 @@
 {
   "Name": "Custom Farming Automate Bridge",
   "Author": "Platonymous",
-  "Version": {
-    "MajorVersion": 1,
-    "MinorVersion": 0,
-    "PatchVersion": 1,
-    "Build": null
-  },
+  "Version": "1.0.1",
   "Description": "Allows Custom Farming to work with Automate",
   "UniqueID": "Platonymous.CFAutomate",
   "EntryDll": "CFAutomate.dll",
+  "MinimumApiVersion": "2.6-beta",
+  "UpdateKeys": [],
   "Dependencies": [
     {
       "UniqueID": "Pathoschild.Automate"
@@ -17,6 +14,5 @@
     {
       "UniqueID": "Platonymous.CustomFarming"
     }
-  ],
-  "UpdateKeys": [ ]
+  ]
 }

--- a/CFAutomate/packages.config
+++ b/CFAutomate/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net452" />
-  <package id="Pathoschild.Stardew.ModBuildConfig" version="1.7.1" targetFramework="net45" />
+  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.1.0-beta-20180426" targetFramework="net45" />
 </packages>

--- a/Capitalism/Capitalism.csproj
+++ b/Capitalism/Capitalism.csproj
@@ -11,8 +11,6 @@
     <AssemblyName>Capitalism</AssemblyName>
     <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -33,12 +31,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
@@ -68,12 +60,15 @@
       <Private>False</Private>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\analyzers\dotnet\cs\StardewModdingAPI.ModBuildConfig.Analyzer.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.2\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.2\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
+  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.2\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.2\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
+    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
   </Target>
 </Project>

--- a/Capitalism/manifest.json
+++ b/Capitalism/manifest.json
@@ -1,15 +1,12 @@
 {
   "Name": "Capitalism",
   "Author": "Platonymous",
-  "Version": {
-    "MajorVersion": 0,
-    "MinorVersion": 1,
-    "PatchVersion": 1,
-    "Build": null
-  },
+  "Version": "0.1.1",
   "Description": "Test Mod",
   "UniqueID": "Platonymous.Capitalism",
   "EntryDll": "Capitalism.dll",
+  "MinimumApiVersion": "2.6-beta",
+  "UpdateKeys": [],
   "Dependencies": [
     {
       "UniqueID": "Platonymous.Visualize"

--- a/Capitalism/packages.config
+++ b/Capitalism/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.0.2" targetFramework="net462" />
+  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.1.0-beta-20180426" targetFramework="net462" />
 </packages>

--- a/CustomElementHandler/CustomElementHandler.csproj
+++ b/CustomElementHandler/CustomElementHandler.csproj
@@ -48,17 +48,18 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="manifest.json" />
-    <None Include="packages.config">
-      <SubType>Designer</SubType>
-    </None>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\analyzers\dotnet\cs\StardewModdingAPI.ModBuildConfig.Analyzer.dll" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\deploy-mod.targets" />
-  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.1\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.1\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
+  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.1\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.1\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
+    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
   </Target>
 </Project>

--- a/CustomElementHandler/manifest.json
+++ b/CustomElementHandler/manifest.json
@@ -1,14 +1,10 @@
 {
   "Name": "Custom Element Handler",
   "Author": "Platonymous",
-  "Version": {
-    "MajorVersion": 1,
-    "MinorVersion": 5,
-    "PatchVersion": 1,
-    "Build": null
-  },
+  "Version": "1.5.1",
   "Description": "SaveHandler for Custom Objects",
   "UniqueID": "Platonymous.CustomElementHandler",
   "EntryDll": "CustomElementHandler.dll",
+  "MinimumApiVersion": "2.6-beta",
   "UpdateKeys": [ "Nexus:1068" ]
 }

--- a/CustomElementHandler/packages.config
+++ b/CustomElementHandler/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" />
-  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.0.1" targetFramework="net45" />
+  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.1.0-beta-20180426" targetFramework="net45" />
 </packages>

--- a/CustomFarming/CustomFarming.csproj
+++ b/CustomFarming/CustomFarming.csproj
@@ -36,9 +36,6 @@
       <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Drawing" />
-    <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
@@ -60,13 +57,16 @@
       <Private>False</Private>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\analyzers\dotnet\cs\StardewModdingAPI.ModBuildConfig.Analyzer.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\deploy-mod.targets" />
-  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.1\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.1\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
+  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.1\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.1\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
+    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
   </Target>
 </Project>

--- a/CustomFarming/customFarmingMod.cs
+++ b/CustomFarming/customFarmingMod.cs
@@ -70,15 +70,15 @@ namespace CustomFarming
 
             if (param[0] == "shop" && Game1.activeClickableMenu is ShopMenu shop)
             {
-                Dictionary<Item, int[]> items = Helper.Reflection.GetPrivateValue<Dictionary<Item, int[]>>(shop, "itemPriceAndStock");
-                List<Item> selling = Helper.Reflection.GetPrivateValue<List<Item>>(shop, "forSale");
+                Dictionary<Item, int[]> items = Helper.Reflection.GetField<Dictionary<Item, int[]>>(shop, "itemPriceAndStock").GetValue();
+                List<Item> selling = Helper.Reflection.GetField<List<Item>>(shop, "forSale").GetValue();
                 List<Item> remove = new List<Item>();
                 List<Item> additions = new List<Item>();
 
                 foreach (Item i in selling)
-                    if (i is Chest chest && machinePile.Keys.Where(f => f.Equals(i.Name)).Any())
+                    if (i is Chest chest && machinePile.Keys.Any(f => f.Equals(i.Name)))
                     {
-                        Item cf = (simpleMachine) machinePile[machinePile.Keys.Where(f => f.Equals(i.Name)).FirstOrDefault()];
+                        Item cf = (simpleMachine) machinePile[machinePile.Keys.FirstOrDefault(f => f.Equals(i.Name))];
                         items.Add(cf, new int[] { chest.preservedParentSheetIndex, int.MaxValue });
                         additions.Add(cf);
                         remove.Add(i);
@@ -125,20 +125,20 @@ namespace CustomFarming
            
             if (Game1.activeClickableMenu is GameMenu)
             {
-                List<IClickableMenu> gameMenuPages = Helper.Reflection.GetPrivateField<List<IClickableMenu>>(Game1.activeClickableMenu, "pages").GetValue();
+                List<IClickableMenu> gameMenuPages = Helper.Reflection.GetField<List<IClickableMenu>>(Game1.activeClickableMenu, "pages").GetValue();
 
                 foreach (IClickableMenu menu in gameMenuPages)
                 {
                     if (menu is CraftingPage)
                     {
                         
-                        Item heldItem = Helper.Reflection.GetPrivateField<Item>(menu, "heldItem").GetValue();
+                        Item heldItem = Helper.Reflection.GetField<Item>(menu, "heldItem").GetValue();
 
                         if (heldItem != null && heldItem is StardewValley.Object && machinesForCrafting.ContainsKey((heldItem as StardewValley.Object).name))
                         {
                             heldItem = machinesForCrafting[(heldItem as StardewValley.Object).name].getOne();
                             
-                            Helper.Reflection.GetPrivateField<Item>(menu, "heldItem").SetValue(heldItem);
+                            Helper.Reflection.GetField<Item>(menu, "heldItem").SetValue(heldItem);
                         }
 
 
@@ -171,7 +171,7 @@ namespace CustomFarming
             {
                
                 GameMenu activeMenu = (GameMenu) Game1.activeClickableMenu;
-                List<IClickableMenu> gameMenuPages = Helper.Reflection.GetPrivateField<List<IClickableMenu>>(activeMenu, "pages").GetValue();
+                List<IClickableMenu> gameMenuPages = Helper.Reflection.GetField<List<IClickableMenu>>(activeMenu, "pages").GetValue();
 
                foreach(IClickableMenu menu in gameMenuPages)
                 {
@@ -210,7 +210,7 @@ namespace CustomFarming
                     }
                 }
 
-                Helper.Reflection.GetPrivateField<List<IClickableMenu>>(Game1.activeClickableMenu, "pages").SetValue(gameMenuPages);
+                Helper.Reflection.GetField<List<IClickableMenu>>(Game1.activeClickableMenu, "pages").SetValue(gameMenuPages);
         
                 
             }

--- a/CustomFarming/manifest.json
+++ b/CustomFarming/manifest.json
@@ -1,19 +1,15 @@
 {
   "Name": "Custom Farming",
   "Author": "Platonymous",
-  "Version": {
-    "MajorVersion": 0,
-    "MinorVersion": 7,
-    "PatchVersion": 0,
-    "Build": null
-  },
+  "Version": "0.7.0",
   "Description": "Helper Mod for Custom Object creation.",
   "UniqueID": "Platonymous.CustomFarming",
   "EntryDll": "CustomFarming.dll",
+  "MinimumApiVersion": "2.6-beta",
+  "UpdateKeys": [ "Nexus:991" ],
   "Dependencies": [
     {
       "UniqueID": "Platonymous.CustomElementHandler"
     }
-  ],
-  "UpdateKeys": [ "Nexus:991" ]
+  ]
 }

--- a/CustomFarming/packages.config
+++ b/CustomFarming/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" />
-  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.0.1" targetFramework="net45" />
+  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.1.0-beta-20180426" targetFramework="net45" />
 </packages>

--- a/CustomFarmingRedux/CustomFarmingRedux.csproj
+++ b/CustomFarmingRedux/CustomFarmingRedux.csproj
@@ -11,8 +11,6 @@
     <AssemblyName>CustomFarmingRedux</AssemblyName>
     <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -33,12 +31,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
@@ -91,12 +83,15 @@
     <Content Include="Machines\Platonymous.NewMachines\newproduce.png" />
     <Content Include="Machines\Platonymous.NewMachines\preview.png" />
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\analyzers\dotnet\cs\StardewModdingAPI.ModBuildConfig.Analyzer.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.2\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.2\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
+  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.2\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.2\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
+    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
   </Target>
 </Project>

--- a/CustomFarmingRedux/manifest.json
+++ b/CustomFarmingRedux/manifest.json
@@ -1,19 +1,15 @@
 {
   "Name": "Custom Farming Redux",
   "Author": "Platonymous",
-  "Version": {
-    "MajorVersion": 2,
-    "MinorVersion": 5,
-    "PatchVersion": 3,
-    "Build": null
-  },
+  "Version": "2.5.3",
   "Description": "Helper Mod for Custom Machine creation.",
   "UniqueID": "Platonymous.CustomFarming",
   "EntryDll": "CustomFarmingRedux.dll",
+  "MinimumApiVersion": "2.6-beta",
+  "UpdateKeys": [ "Nexus:991" ],
   "Dependencies": [
     {
       "UniqueID": "Platonymous.Toolkit"
     }
-  ],
-  "UpdateKeys": [ "Nexus:991" ]
+  ]
 }

--- a/CustomFarmingRedux/packages.config
+++ b/CustomFarmingRedux/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.0.2" targetFramework="net462" />
+  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.1.0-beta-20180426" targetFramework="net462" />
 </packages>

--- a/CustomFurniture/CustomFurniture.cs
+++ b/CustomFurniture/CustomFurniture.cs
@@ -58,7 +58,7 @@ namespace CustomFurniture
             counter = 0;
             tileLocation = tile;
 
-            CustomFurnitureMod.helper.Reflection.GetPrivateField<string>(this, "_description").SetValue(data.description);
+            CustomFurnitureMod.helper.Reflection.GetField<string>(this, "_description").SetValue(data.description);
 
             parentSheetIndex = data.index;
 
@@ -72,7 +72,7 @@ namespace CustomFurniture
             decorTypes.Add("bookcase");
             decorTypes.Add("other");
             string typename = data.type.Contains("table") ? "table" : decorTypes.Contains(data.type) ? "decor" : data.type;
-            furniture_type = data.type.Contains("table") ? 11 : decorTypes.Contains(data.type) ? 8 : CustomFurnitureMod.helper.Reflection.GetPrivateMethod(new Furniture(), "getTypeNumberFromName").Invoke<int>(new[] { data.type });
+            furniture_type = data.type.Contains("table") ? 11 : decorTypes.Contains(data.type) ? 8 : CustomFurnitureMod.helper.Reflection.GetMethod(new Furniture(), "getTypeNumberFromName").Invoke<int>(data.type);
             furniture_type = getTypeFromName(typename);
             defaultSourceRect = new Rectangle(data.index * 16 % texture.Width, data.index * 16 / texture.Width * 16, 1, 1);
             drawHeldObjectLow = false;

--- a/CustomFurniture/CustomFurniture.csproj
+++ b/CustomFurniture/CustomFurniture.csproj
@@ -11,8 +11,6 @@
     <AssemblyName>CustomFurniture</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -67,13 +65,16 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\analyzers\dotnet\cs\StardewModdingAPI.ModBuildConfig.Analyzer.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\deploy-mod.targets" />
-  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.1\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.1\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
+  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.1\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.1\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
+    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
   </Target>
 </Project>

--- a/CustomFurniture/CustomFurnitureMod.cs
+++ b/CustomFurniture/CustomFurnitureMod.cs
@@ -74,15 +74,15 @@ namespace CustomFurniture
 
             if (param[0] == "shop" && Game1.activeClickableMenu is ShopMenu shop)
             {
-                Dictionary<Item, int[]> items = Helper.Reflection.GetPrivateValue<Dictionary<Item, int[]>>(shop, "itemPriceAndStock");
-                List<Item> selling = Helper.Reflection.GetPrivateValue<List<Item>>(shop, "forSale");
+                Dictionary<Item, int[]> items = Helper.Reflection.GetField<Dictionary<Item, int[]>>(shop, "itemPriceAndStock").GetValue();
+                List<Item> selling = Helper.Reflection.GetField<List<Item>>(shop, "forSale").GetValue();
                 List<Item> remove = new List<Item>();
                 List<Item> additions = new List<Item>();
 
                 foreach (Item i in selling)
-                    if (i is Chest chest && furniturePile.Keys.Where(f => f.Equals(i.Name)).Any())
+                    if (i is Chest chest && furniturePile.Keys.Any(f => f.Equals(i.Name)))
                     {
-                        Item cf = furniturePile[furniturePile.Keys.Where(f => f.Equals(i.Name)).FirstOrDefault()];
+                        Item cf = furniturePile[furniturePile.Keys.FirstOrDefault(f => f.Equals(i.Name))];
                         items.Add(cf, new int[] { chest.preservedParentSheetIndex, int.MaxValue });
                         additions.Add(cf);
                         remove.Add(i);
@@ -151,7 +151,7 @@ namespace CustomFurniture
 
         private bool meetsConditions(string conditions)
         {
-            return (Helper.Reflection.GetPrivateMethod(Game1.currentLocation, "checkEventPrecondition").Invoke<int>(new object[] { "9999984/" + conditions }) != -1);
+            return (Helper.Reflection.GetMethod(Game1.currentLocation, "checkEventPrecondition").Invoke<int>("9999984/" + conditions) != -1);
         }
 
         private void MenuEvents_MenuChanged(object sender, EventArgsClickableMenuChanged e)
@@ -159,9 +159,9 @@ namespace CustomFurniture
             if (Game1.activeClickableMenu is ShopMenu)
             {
                 ShopMenu shop = (ShopMenu)Game1.activeClickableMenu;
-                Dictionary<Item, int[]> items = Helper.Reflection.GetPrivateValue<Dictionary<Item, int[]>>(shop, "itemPriceAndStock");
-                List<Item> selling = Helper.Reflection.GetPrivateValue<List<Item>>(shop, "forSale");
-                int currency = Helper.Reflection.GetPrivateValue<int>(shop, "currency");
+                Dictionary<Item, int[]> items = Helper.Reflection.GetField<Dictionary<Item, int[]>>(shop, "itemPriceAndStock").GetValue();
+                List<Item> selling = Helper.Reflection.GetField<List<Item>>(shop, "forSale").GetValue();
+                int currency = Helper.Reflection.GetField<int>(shop, "currency").GetValue();
                 bool isCatalogue = (currency == 0 && selling.Count > 0 && selling[0] is Furniture);
                 string shopkeeper = "Robin";
 

--- a/CustomFurniture/manifest.json
+++ b/CustomFurniture/manifest.json
@@ -1,19 +1,15 @@
 {
   "Name": "Custom Furniture",
   "Author": "Platonymous",
-  "Version": {
-    "MajorVersion": 0,
-    "MinorVersion": 8,
-    "PatchVersion": 1,
-    "Build": null
-  },
+  "Version": "0.8.1",
   "Description": "Helper Mod for Custom Furniture creation.",
   "UniqueID": "Platonymous.CustomFurniture",
   "EntryDll": "CustomFurniture.dll",
+  "MinimumApiVersion": "2.6-beta",
+  "UpdateKeys": [ "Nexus:1254" ],
   "Dependencies": [
     {
       "UniqueID": "Platonymous.CustomElementHandler"
     }
-  ],
-  "UpdateKeys": [ "Nexus:1254" ]
+  ]
 }

--- a/CustomFurniture/packages.config
+++ b/CustomFurniture/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.0.1" targetFramework="net45" />
+  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.1.0-beta-20180426" targetFramework="net45" />
 </packages>

--- a/CustomFurnitureAnywhere/CustomFurnitureAnywhere.csproj
+++ b/CustomFurnitureAnywhere/CustomFurnitureAnywhere.csproj
@@ -11,8 +11,6 @@
     <AssemblyName>CustomFurnitureAnywhere</AssemblyName>
     <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -76,12 +74,15 @@
       <Private>False</Private>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\analyzers\dotnet\cs\StardewModdingAPI.ModBuildConfig.Analyzer.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.2\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.2\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
+  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.2\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.2\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
+    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
   </Target>
 </Project>

--- a/CustomFurnitureAnywhere/FurnitureAnywhereModFix.cs
+++ b/CustomFurnitureAnywhere/FurnitureAnywhereModFix.cs
@@ -36,7 +36,7 @@ namespace CustomFurnitureAnywhere
  
                 if (e.OldItem != null && e.OldItem is AnywhereCustomFurniture)
                 {
-                    CustomFurnitureAnywhereMod.modhelper.Reflection.GetPrivateMethod(__instance, "RestoreVanillaObjects").Invoke();
+                    CustomFurnitureAnywhereMod.modhelper.Reflection.GetMethod(__instance, "RestoreVanillaObjects").Invoke();
                     return false;
                 }
             

--- a/CustomFurnitureAnywhere/manifest.json
+++ b/CustomFurnitureAnywhere/manifest.json
@@ -1,15 +1,12 @@
 {
   "Name": "Custom Furniture Anywhere",
   "Author": "Platonymous",
-  "Version": {
-    "MajorVersion": 0,
-    "MinorVersion": 8,
-    "PatchVersion": 1,
-    "Build": null
-  },
+  "Version": "0.8.1",
   "Description": "Makes Custom Furniture work with Furniture Anywhere",
   "UniqueID": "Platonymous.CustomFurnitureAnywhere",
   "EntryDll": "CustomFurnitureAnywhere.dll",
+  "MinimumApiVersion": "2.6-beta",
+  "UpdateKeys": [ "Nexus:1254" ],
   "Dependencies": [
     {
       "UniqueID": "Platonymous.CustomElementHandler"
@@ -23,6 +20,5 @@
     {
       "UniqueID": "Entoarox.EntoaroxFramework"
     }
-  ],
-  "UpdateKeys": [ "Nexus:1254" ]
+  ]
 }

--- a/CustomFurnitureAnywhere/packages.config
+++ b/CustomFurnitureAnywhere/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.0.2" targetFramework="net462" />
+  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.1.0-beta-20180426" targetFramework="net462" />
 </packages>

--- a/CustomNPC/CustomNPC.csproj
+++ b/CustomNPC/CustomNPC.csproj
@@ -11,8 +11,6 @@
     <AssemblyName>CustomNPC</AssemblyName>
     <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -33,12 +31,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
@@ -51,26 +43,18 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="manifest.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
+    <None Include="manifest.json" />
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\analyzers\dotnet\cs\StardewModdingAPI.ModBuildConfig.Analyzer.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.1.6.0\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.6.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
+  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.6.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.1.6.0\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
-  </Target>
-  <Target Name="AfterBuild">
-    <PropertyGroup>
-      <ModPath>$(GamePath)\Mods\$(TargetName)</ModPath>
-    </PropertyGroup>
-    <Copy SourceFiles="$(TargetDir)\$(TargetName).dll" DestinationFolder="$(ModPath)" />
-    <Copy SourceFiles="$(TargetDir)\$(TargetName).pdb" DestinationFolder="$(ModPath)" Condition="Exists('$(TargetDir)\$(TargetName).pdb')" />
-    <Copy SourceFiles="$(TargetDir)\$(TargetName).dll.mdb" DestinationFolder="$(ModPath)" Condition="Exists('$(TargetDir)\$(TargetName).dll.mdb')" />
-    <Copy SourceFiles="$(ProjectDir)manifest.json" DestinationFolder="$(ModPath)" />
+    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
   </Target>
 </Project>

--- a/CustomNPC/CustomNPCMod.cs
+++ b/CustomNPC/CustomNPCMod.cs
@@ -93,9 +93,9 @@ namespace CustomNPC
             {
                 Type apiClass = Type.GetType("NPCMapLocations.MapModMain, NPCMapLocations");
 
-                IPrivateField<Dictionary<string, string>> indoorLocationsF = Helper.Reflection.GetPrivateField<Dictionary<string, string>>(apiClass, "indoorLocations");
-                IPrivateField<Dictionary<string, string>> startingLocationsF = Helper.Reflection.GetPrivateField<Dictionary<string, string>>(apiClass, "startingLocations");
-                IPrivateField<Dictionary<string, Double[]>> locationVectorsF = Helper.Reflection.GetPrivateField<Dictionary<string, Double[]>>(apiClass, "locationVectors");
+                IReflectedField<Dictionary<string, string>> indoorLocationsF = Helper.Reflection.GetField<Dictionary<string, string>>(apiClass, "indoorLocations");
+                IReflectedField<Dictionary<string, string>> startingLocationsF = Helper.Reflection.GetField<Dictionary<string, string>>(apiClass, "startingLocations");
+                IReflectedField<Dictionary<string, Double[]>> locationVectorsF = Helper.Reflection.GetField<Dictionary<string, Double[]>>(apiClass, "locationVectors");
 
                 Dictionary<string, string> indoorLocations = indoorLocationsF.GetValue();
                 Dictionary<string, string> startingLocations = startingLocationsF.GetValue();
@@ -222,9 +222,9 @@ namespace CustomNPC
                 return true;
 
             if (conditions.StartsWith("NOT"))
-                return !(Helper.Reflection.GetPrivateMethod(Game1.currentLocation, "checkEventPrecondition").Invoke<int>(new object[] { "9999984/" + conditions.Replace("NOT ", "") }) != -1);
+                return Helper.Reflection.GetMethod(Game1.currentLocation, "checkEventPrecondition").Invoke<int>("9999984/" + conditions.Replace("NOT ", "")) == -1;
 
-            return (Helper.Reflection.GetPrivateMethod(Game1.currentLocation, "checkEventPrecondition").Invoke<int>(new object[] { "9999984/" + conditions }) != -1);
+            return (Helper.Reflection.GetMethod(Game1.currentLocation, "checkEventPrecondition").Invoke<int>("9999984/" + conditions) != -1);
         }
 
         private void loadNPCs()
@@ -386,7 +386,7 @@ namespace CustomNPC
 
             if (Game1.CurrentEvent is Event && Game1.CurrentEvent.isFestival)
             {
-                GameLocation temp = (GameLocation)Helper.Reflection.GetPrivateValue<GameLocation>(Game1.CurrentEvent, "temporaryLocation");
+                GameLocation temp = Helper.Reflection.GetField<GameLocation>(Game1.CurrentEvent, "temporaryLocation").GetValue();
                 GameEvents.OneSecondTick += GameEvents_OneSecondTick;
             }
             else if (shoplocations.ContainsKey(Game1.currentLocation.name))
@@ -583,7 +583,7 @@ namespace CustomNPC
                         mapLayer.Tiles[(int)_x.Y, (int)_y.Y] = newTile;
 
                         if (location != null && (layer.Id == "Buildings" || layer.Id == "Front"))
-                            Helper.Reflection.GetPrivateMethod(location, "adjustMapLightPropertiesForLamp").Invoke(mapLayer.Tiles[(int)_x.Y, (int)_y.Y].TileIndex, (int)_x.Y, (int)_y.Y, mapLayer.Id);
+                            Helper.Reflection.GetMethod(location, "adjustMapLightPropertiesForLamp").Invoke(mapLayer.Tiles[(int)_x.Y, (int)_y.Y].TileIndex, (int)_x.Y, (int)_y.Y, mapLayer.Id);
 
                         foreach (var prop in sourceTile.Properties)
                             newTile.Properties.Add(prop);
@@ -624,7 +624,7 @@ namespace CustomNPC
                     int x = int.Parse(posString[0]);
                     int y = int.Parse(posString[1]);
                     int face = int.Parse(posString[2]);
-                    GameLocation temp = (GameLocation)Helper.Reflection.GetPrivateValue<GameLocation>(Game1.CurrentEvent, "temporaryLocation");
+                    GameLocation temp = Helper.Reflection.GetField<GameLocation>(Game1.CurrentEvent, "temporaryLocation").GetValue();
                     if (temp is GameLocation && Game1.CurrentEvent.actors.Find(n => n.name == blueprint.name) is null)
                     {
                         NPC anpc = new NPC(getSprite(blueprint), new Vector2((float)(x * Game1.tileSize), (float)(y * Game1.tileSize)), temp.Name, face, blueprint.name, (Dictionary<int, int[]>)null, getPortrait(blueprint), true);
@@ -960,7 +960,7 @@ namespace CustomNPC
         private void setupActorsForFlowerDanceMainEvent()
         {
             Event current = Game1.CurrentEvent;
-            GameLocation temp = (GameLocation)Helper.Reflection.GetPrivateValue<GameLocation>(Game1.CurrentEvent, "temporaryLocation");
+            GameLocation temp = (GameLocation)Helper.Reflection.GetField<GameLocation>(Game1.CurrentEvent, "temporaryLocation").GetValue();
             string[] split = new string[] { "loadActors", "MainEvent" };
             current.actors.Clear();
 
@@ -978,13 +978,13 @@ namespace CustomNPC
                         string key = source.ElementAt<KeyValuePair<string, string>>(index).Key;
 
                         if (key != null && Game1.getCharacterFromName(key, false) != null)
-                            Helper.Reflection.GetPrivateMethod(Game1.CurrentEvent, "addActor").Invoke(new object[] { key, x, y, facingDirection, temp });
+                            Helper.Reflection.GetMethod(Game1.CurrentEvent, "addActor").Invoke(key, x, y, facingDirection, temp);
                     }
         }
 
         private void setUpFlowerDanceMainEvent()
         {
-            Dictionary<string, string> festivalData = Helper.Reflection.GetPrivateValue<Dictionary<string, string>>(Game1.CurrentEvent, "festivalData");
+            Dictionary<string, string> festivalData = Helper.Reflection.GetField<Dictionary<string, string>>(Game1.CurrentEvent, "festivalData").GetValue();
 
             Game1.CurrentEvent.eventCommands = festivalData["mainEvent"].Split('/');
             Game1.CurrentEvent.CurrentCommand = 0;

--- a/CustomNPC/manifest.json
+++ b/CustomNPC/manifest.json
@@ -1,14 +1,10 @@
 {
   "Name": "Custom NPC",
   "Author": "Platonymous",
-  "Version": {
-    "MajorVersion": 0,
-    "MinorVersion": 9,
-    "PatchVersion": 9,
-    "Build": ""
-  },
+  "Version": "0.9.9",
   "Description": "Helps you add new NPCs to the Game",
   "UniqueID": "Platonymous.CustomNPC",
   "EntryDll": "CustomNPC.dll",
+  "MinimumApiVersion": "2.6-beta",
   "UpdateKeys": [ "Nexus:1607" ]
 }

--- a/CustomNPC/packages.config
+++ b/CustomNPC/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Pathoschild.Stardew.ModBuildConfig" version="1.6.0" targetFramework="net462" />
+  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.1.0-beta-20180426" targetFramework="net462" />
 </packages>

--- a/CustomTV/CustomTV.csproj
+++ b/CustomTV/CustomTV.csproj
@@ -49,13 +49,16 @@
       <Private>False</Private>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\analyzers\dotnet\cs\StardewModdingAPI.ModBuildConfig.Analyzer.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\deploy-mod.targets" />
-  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
+  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
+    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
   </Target>
 </Project>

--- a/CustomTV/TVIntercept.cs
+++ b/CustomTV/TVIntercept.cs
@@ -24,8 +24,8 @@ namespace CustomTV
 
         private static Dictionary<string, Action<TV, TemporaryAnimatedSprite,StardewValley.Farmer,string>> actions = new Dictionary<string, Action<TV, TemporaryAnimatedSprite, StardewValley.Farmer, string>>();
 
-        public IPrivateField<TemporaryAnimatedSprite> tvScreen;
-        public IPrivateField<TemporaryAnimatedSprite> tvOverlay;
+        public IReflectedField<TemporaryAnimatedSprite> tvScreen;
+        public IReflectedField<TemporaryAnimatedSprite> tvOverlay;
         public static TVIntercept activeIntercept;
 
         public TVIntercept()
@@ -41,8 +41,8 @@ namespace CustomTV
              : base(tv.parentSheetIndex, tv.tileLocation)
         {
             this.tv = tv;
-            tvScreen = CustomTVMod.Modhelper.Reflection.GetPrivateField<TemporaryAnimatedSprite>(tv, "screen");
-            tvOverlay = CustomTVMod.Modhelper.Reflection.GetPrivateField<TemporaryAnimatedSprite>(tv, "screenOverlay");
+            tvScreen = CustomTVMod.Modhelper.Reflection.GetField<TemporaryAnimatedSprite>(tv, "screen");
+            tvOverlay = CustomTVMod.Modhelper.Reflection.GetField<TemporaryAnimatedSprite>(tv, "screenOverlay");
         }
 
         public static void addChannel(string id, string name, Action<TV, TemporaryAnimatedSprite, StardewValley.Farmer, string> action)
@@ -232,15 +232,15 @@ namespace CustomTV
 
         private string getFortuneTellerOpening()
         {
-            IPrivateMethod method =  CustomTVMod.Modhelper.Reflection.GetPrivateMethod(tv, "getFortuneTellerOpening");
-            return method.Invoke<string>(new object[0]);
+            IReflectedMethod method =  CustomTVMod.Modhelper.Reflection.GetMethod(tv, "getFortuneTellerOpening");
+            return method.Invoke<string>();
             
         }
 
         private string getWeatherChannelOpening()
         {
-            IPrivateMethod method = CustomTVMod.Modhelper.Reflection.GetPrivateMethod(tv, "getWeatherChannelOpening");
-            return method.Invoke<string>(new object[0]);
+            IReflectedMethod method = CustomTVMod.Modhelper.Reflection.GetMethod(tv, "getWeatherChannelOpening");
+            return method.Invoke<string>();
         }
 
         public float getScreenSizeModifier()
@@ -265,38 +265,38 @@ namespace CustomTV
 
         private void setWeatherOverlay()
         {
-            IPrivateMethod method = CustomTVMod.Modhelper.Reflection.GetPrivateMethod(tv, "setWeatherOverlay");
-            method.Invoke(new object[0]);
+            IReflectedMethod method = CustomTVMod.Modhelper.Reflection.GetMethod(tv, "setWeatherOverlay");
+            method.Invoke();
         }
 
         private string getTodaysTip()
         {
-            IPrivateMethod method = CustomTVMod.Modhelper.Reflection.GetPrivateMethod(tv, "getTodaysTip");
-            return method.Invoke<string>(new object[0]);
+            IReflectedMethod method = CustomTVMod.Modhelper.Reflection.GetMethod(tv, "getTodaysTip");
+            return method.Invoke<string>();
         }
 
         private string[] getWeeklyRecipe()
         {
-            IPrivateMethod method = CustomTVMod.Modhelper.Reflection.GetPrivateMethod(tv, "getWeeklyRecipe");
-            return method.Invoke<string[]>(new object[0]);
+            IReflectedMethod method = CustomTVMod.Modhelper.Reflection.GetMethod(tv, "getWeeklyRecipe");
+            return method.Invoke<string[]>();
         }
 
         private string getWeatherForecast()
         {
-            IPrivateMethod method = CustomTVMod.Modhelper.Reflection.GetPrivateMethod(tv, "getWeatherForecast");
-            return method.Invoke<string>(new object[0]);
+            IReflectedMethod method = CustomTVMod.Modhelper.Reflection.GetMethod(tv, "getWeatherForecast");
+            return method.Invoke<string>();
         }
 
         private void setFortuneOverlay()
         {
-            IPrivateMethod method = CustomTVMod.Modhelper.Reflection.GetPrivateMethod(tv, "setFortuneOverlay");
-            method.Invoke(new object[0]);
+            IReflectedMethod method = CustomTVMod.Modhelper.Reflection.GetMethod(tv, "setFortuneOverlay");
+            method.Invoke();
         }
 
         private string getFortuneForecast()
         {
-            IPrivateMethod method = CustomTVMod.Modhelper.Reflection.GetPrivateMethod(tv, "getFortuneForecast");
-            return method.Invoke<string>(new object[0]);
+            IReflectedMethod method = CustomTVMod.Modhelper.Reflection.GetMethod(tv, "getFortuneForecast");
+            return method.Invoke<string>();
         }	
 	
         public override bool placementAction(GameLocation location, int x, int y, StardewValley.Farmer who = null)
@@ -328,7 +328,7 @@ namespace CustomTV
         {
            
             tv = new TV(((TV) replacement).parentSheetIndex, ((TV)replacement).tileLocation);
-            tvScreen = CustomTVMod.Modhelper.Reflection.GetPrivateField<TemporaryAnimatedSprite>(tv, "screen");
+            tvScreen = CustomTVMod.Modhelper.Reflection.GetField<TemporaryAnimatedSprite>(tv, "screen");
 
             tileLocation = tv.tileLocation;
             parentSheetIndex = tv.parentSheetIndex;

--- a/CustomTV/manifest.json
+++ b/CustomTV/manifest.json
@@ -1,19 +1,15 @@
 {
   "Name": "Custom TV",
   "Author": "Platonymous",
-  "Version": {
-    "MajorVersion": 1,
-    "MinorVersion": 2,
-    "PatchVersion": 0,
-    "Build": null
-  },
+  "Version": "1.2.0",
   "Description": "Custom TV Channels.",
   "UniqueID": "Platonymous.CustomTV",
   "EntryDll": "CustomTV.dll",
+  "MinimumApiVersion": "2.6-beta",
+  "UpdateKeys": [ "Nexus:1139" ],
   "Dependencies": [
     {
       "UniqueID": "Platonymous.CustomElementHandler"
     }
-  ],
-  "UpdateKeys": [ "Nexus:1139" ]
+  ]
 }

--- a/CustomTV/packages.config
+++ b/CustomTV/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Pathoschild.Stardew.ModBuildConfig" version="1.7.1" targetFramework="net45" />
+  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.1.0-beta-20180426" targetFramework="net45" />
 </packages>

--- a/HarpOfYobaRedux/HarpOfYobaRedux.csproj
+++ b/HarpOfYobaRedux/HarpOfYobaRedux.csproj
@@ -78,13 +78,16 @@
       <Private>False</Private>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\analyzers\dotnet\cs\StardewModdingAPI.ModBuildConfig.Analyzer.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\deploy-mod.targets" />
-  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
+  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
+    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
   </Target>
 </Project>

--- a/HarpOfYobaRedux/manifest.json
+++ b/HarpOfYobaRedux/manifest.json
@@ -1,19 +1,15 @@
 {
   "Name": "Harp of Yoba Redux",
   "Author": "Platonymous",
-  "Version": {
-    "MajorVersion": 2,
-    "MinorVersion": 3,
-    "PatchVersion": 0,
-    "Build": null
-  },
+  "Version": "2.3.0",
   "Description": "Adds The Harp of Yoba to the game.",
   "UniqueID": "Platonymous.HarpOfYobaRedux",
   "EntryDll": "HarpOfYobaRedux.dll",
+  "MinimumApiVersion": "2.6-beta",
+  "UpdateKeys": [ "Nexus:914" ],
   "Dependencies": [
     {
       "UniqueID": "Platonymous.Toolkit"
     }
-  ],
-  "UpdateKeys": [ "Nexus:914" ]
+  ]
 }

--- a/HarpOfYobaRedux/packages.config
+++ b/HarpOfYobaRedux/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net452" />
-  <package id="Pathoschild.Stardew.ModBuildConfig" version="1.7.1" targetFramework="net45" />
+  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.1.0-beta-20180426" targetFramework="net45" />
 </packages>

--- a/InteractiveMapLayer/InteractiveMapLayer.csproj
+++ b/InteractiveMapLayer/InteractiveMapLayer.csproj
@@ -36,8 +36,6 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
@@ -48,13 +46,16 @@
     <None Include="manifest.json" />
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\analyzers\dotnet\cs\StardewModdingAPI.ModBuildConfig.Analyzer.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\deploy-mod.targets" />
-  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
+  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
+    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
   </Target>
 </Project>

--- a/InteractiveMapLayer/manifest.json
+++ b/InteractiveMapLayer/manifest.json
@@ -1,14 +1,10 @@
 {
   "Name": "Interactive Map Layer",
   "Author": "Platonymous",
-  "Version": {
-    "MajorVersion": 0,
-    "MinorVersion": 1,
-    "PatchVersion": 1,
-    "Build": null
-  },
+  "Version": "0.1.1",
   "Description": "Adds more interactivity to maps",
   "UniqueID": "Platonymous.InteractiveMapLayer",
   "EntryDll": "InteractiveMapLayer.dll",
+  "MinimumApiVersion": "2.6-beta",
   "UpdateKeys": [ ]
 }

--- a/InteractiveMapLayer/packages.config
+++ b/InteractiveMapLayer/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net452" />
-  <package id="Pathoschild.Stardew.ModBuildConfig" version="1.7.1" targetFramework="net45" />
+  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.1.0-beta-20180426" targetFramework="net45" />
 </packages>

--- a/JunimoFarm/JunimoFarm.csproj
+++ b/JunimoFarm/JunimoFarm.csproj
@@ -50,13 +50,16 @@
     <None Include="manifest.json" />
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\analyzers\dotnet\cs\StardewModdingAPI.ModBuildConfig.Analyzer.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\deploy-mod.targets" />
-  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
+  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
+    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
   </Target>
 </Project>

--- a/JunimoFarm/manifest.json
+++ b/JunimoFarm/manifest.json
@@ -1,14 +1,10 @@
 {
   "Name": "Junimo Farm",
   "Author": "Platonymous",
-  "Version": {
-    "MajorVersion": 1,
-    "MinorVersion": 1,
-    "PatchVersion": 3,
-    "Build": null
-  },
+  "Version": "1.1.3",
   "Description": "Let Junimos help you on the farm.",
   "UniqueID": "Platonymous.JunimoFarm",
   "EntryDll": "JunimoFarm.dll",
+  "MinimumApiVersion": "2.6-beta",
   "UpdateKeys": [ "Nexus:984" ]
 }

--- a/JunimoFarm/packages.config
+++ b/JunimoFarm/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net452" />
-  <package id="Pathoschild.Stardew.ModBuildConfig" version="1.7.1" targetFramework="net45" />
+  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.1.0-beta-20180426" targetFramework="net45" />
 </packages>

--- a/MoreMapLayers/MapDisplayDeviceIntercept.cs
+++ b/MoreMapLayers/MapDisplayDeviceIntercept.cs
@@ -24,7 +24,7 @@ namespace MoreMapLayers
         {
             
             device = xna;
-            textures = MoreMapLayers.helper.Reflection.GetPrivateValue<Dictionary<TileSheet, Texture2D>>(device, "m_tileSheetTextures");
+            textures = MoreMapLayers.helper.Reflection.GetField<Dictionary<TileSheet, Texture2D>>(device, "m_tileSheetTextures").GetValue();
         }
 
         public void BeginScene(SpriteBatch b)

--- a/MoreMapLayers/MoreMapLayers.csproj
+++ b/MoreMapLayers/MoreMapLayers.csproj
@@ -44,13 +44,16 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\analyzers\dotnet\cs\StardewModdingAPI.ModBuildConfig.Analyzer.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\deploy-mod.targets" />
-  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
+  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
+    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
   </Target>
 </Project>

--- a/MoreMapLayers/manifest.json
+++ b/MoreMapLayers/manifest.json
@@ -1,14 +1,10 @@
 {
   "Name": "More Map Layers",
   "Author": "Platonymous",
-  "Version": {
-    "MajorVersion": 1,
-    "MinorVersion": 1,
-    "PatchVersion": 1,
-    "Build": null
-  },
+  "Version": "1.1.1",
   "Description": "Allows the use of additional layers on maps between Back and Buildings",
   "UniqueID": "Platonymous.MoreMapLayers",
   "EntryDll": "MoreMapLayers.dll",
+  "MinimumApiVersion": "2.6-beta",
   "UpdateKeys": [ "Nexus:1134" ]
 }

--- a/MoreMapLayers/packages.config
+++ b/MoreMapLayers/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Pathoschild.Stardew.ModBuildConfig" version="1.7.1" targetFramework="net45" />
+  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.1.0-beta-20180426" targetFramework="net45" />
 </packages>

--- a/NewBuilding/Aquaponics.csproj
+++ b/NewBuilding/Aquaponics.csproj
@@ -50,13 +50,16 @@
       <Private>False</Private>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\analyzers\dotnet\cs\StardewModdingAPI.ModBuildConfig.Analyzer.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\deploy-mod.targets" />
-  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
+  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
+    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
   </Target>
 </Project>

--- a/NewBuilding/AquaponicsMod.cs
+++ b/NewBuilding/AquaponicsMod.cs
@@ -42,7 +42,7 @@ namespace Aquaponics
             if(e.NewMenu is CarpenterMenu carpenter)
             {
                 MenuEvents.MenuClosed += MenuEvents_MenuClosed;
-                List<BluePrint> blueprints = Helper.Reflection.GetPrivateValue<List<BluePrint>>(carpenter, "blueprints");
+                List<BluePrint> blueprints = Helper.Reflection.GetField<List<BluePrint>>(carpenter, "blueprints").GetValue();
                 BluePrint newBuildongBluePrint = CreateGreenhouse();
                 blueprints.Add(newBuildongBluePrint);
                 Game1.activeClickableMenu = carpenter;
@@ -57,7 +57,7 @@ namespace Aquaponics
             {
                 if (carpenter.CurrentBlueprint.name == "Aquaponics")
                 {
-                    IPrivateField<Building> cBuilding = Helper.Reflection.GetPrivateField<Building>(carpenter, "currentBuilding");
+                    IReflectedField<Building> cBuilding = Helper.Reflection.GetField<Building>(carpenter, "currentBuilding");
 
                     if (!(cBuilding.GetValue() is Aquaponics))
                     {

--- a/NewBuilding/manifest.json
+++ b/NewBuilding/manifest.json
@@ -1,19 +1,15 @@
 {
   "Name": "Aquaponics",
   "Author": "BashNinja",
-  "Version": {
-    "MajorVersion": 0,
-    "MinorVersion": 1,
-    "PatchVersion": 1,
-    "Build": null
-  },
+  "Version": "0.1.1",
   "Description": "Test Mod for CEH 1.3 & SMAPI 1.14",
   "UniqueID": "BashNinja.Aquaponics",
   "EntryDll": "GHAquaponics.dll",
+  "MinimumApiVersion": "2.6-beta",
+  "UpdateKeys": [],
   "Dependencies": [
     {
       "UniqueID": "Platonymous.CustomElementHandler"
     }
-  ],
-  "UpdateKeys": [ ]
+  ]
 }

--- a/NewBuilding/packages.config
+++ b/NewBuilding/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Pathoschild.Stardew.ModBuildConfig" version="1.7.1" targetFramework="net45" />
+  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.1.0-beta-20180426" targetFramework="net45" />
 </packages>

--- a/NewMachinesPack/NewMachinesPack.csproj
+++ b/NewMachinesPack/NewMachinesPack.csproj
@@ -57,13 +57,16 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\analyzers\dotnet\cs\StardewModdingAPI.ModBuildConfig.Analyzer.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\deploy-mod.targets" />
-  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
+  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
+    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
   </Target>
 </Project>

--- a/NewMachinesPack/manifest.json
+++ b/NewMachinesPack/manifest.json
@@ -1,14 +1,10 @@
 {
   "Name": "New Machines Pack for Custom Farming",
   "Author": "Platonymous",
-  "Version": {
-    "MajorVersion": 1,
-    "MinorVersion": 0,
-    "PatchVersion": 2,
-    "Build": null
-  },
+  "Version": "1.0.2",
   "Description": "Adds new Machines to the game",
   "UniqueID": "Platonymous.MachinePack",
   "EntryDll": "NewMachinesPack.dll",
-  "UpdateKeys": [ ]
+  "MinimumApiVersion": "2.6-beta",
+  "UpdateKeys": []
 }

--- a/NewMachinesPack/packages.config
+++ b/NewMachinesPack/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net462" />
-  <package id="Pathoschild.Stardew.ModBuildConfig" version="1.7.1" targetFramework="net45" />
+  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.1.0-beta-20180426" targetFramework="net45" />
 </packages>

--- a/NoSoilDecayRedux/NoSoilDecayRedux.csproj
+++ b/NoSoilDecayRedux/NoSoilDecayRedux.csproj
@@ -58,13 +58,16 @@
       <Private>False</Private>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\analyzers\dotnet\cs\StardewModdingAPI.ModBuildConfig.Analyzer.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\deploy-mod.targets" />
-  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
+  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
+    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
   </Target>
 </Project>

--- a/NoSoilDecayRedux/manifest.json
+++ b/NoSoilDecayRedux/manifest.json
@@ -1,19 +1,15 @@
 {
   "Name": "No Soil Decay Redux",
   "Author": "Platonymous",
-  "Version": {
-    "MajorVersion": 1,
-    "MinorVersion": 4,
-    "PatchVersion": 2,
-    "Build": null
-  },
+  "Version": "1.4.2",
   "Description": "Stops soil from decaying",
   "UniqueID": "Platonymous.NoSoilDecayRedux",
   "EntryDll": "NoSoilDecayRedux.dll",
+  "MinimumApiVersion": "2.6-beta",
+  "UpdateKeys": [ "Nexus:1084" ],
   "Dependencies": [
     {
       "UniqueID": "Platonymous.Toolkit"
     }
-  ],
-  "UpdateKeys": [ "Nexus:1084" ]
+  ]
 }

--- a/NoSoilDecayRedux/packages.config
+++ b/NoSoilDecayRedux/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net452" />
-  <package id="Pathoschild.Stardew.ModBuildConfig" version="1.7.1" targetFramework="net45" />
+  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.1.0-beta-20180426" targetFramework="net45" />
 </packages>

--- a/PelicanTTS/PelicanTTS.csproj
+++ b/PelicanTTS/PelicanTTS.csproj
@@ -61,14 +61,15 @@
   </ItemGroup>
   <ItemGroup>
     <Analyzer Include="..\packages\AWSSDK.Polly.3.3.3.1\analyzers\dotnet\cs\AWSSDK.Polly.CodeAnalysis.dll" />
+    <Analyzer Include="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\analyzers\dotnet\cs\StardewModdingAPI.ModBuildConfig.Analyzer.dll" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\deploy-mod.targets" />
-  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
+  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
+    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
   </Target>
 </Project>

--- a/PelicanTTS/SpeechHandler.cs
+++ b/PelicanTTS/SpeechHandler.cs
@@ -176,8 +176,8 @@ namespace PelicanTTS
             else if (Game1.activeClickableMenu is LetterViewerMenu lvm)
             {
                 setVoice("default");
-                List<string> mailMessage = Helper.Reflection.GetPrivateValue<List<string>>(lvm, "mailMessage");
-                string letter = mailMessage[Helper.Reflection.GetPrivateValue<int>(lvm, "page")];
+                List<string> mailMessage = Helper.Reflection.GetField<List<string>>(lvm, "mailMessage").GetValue();
+                string letter = mailMessage[Helper.Reflection.GetField<int>(lvm, "page").GetValue()];
                 currentText = letter;
                 lastDialog = letter;
             }

--- a/PelicanTTS/SpeechHandlerPolly.cs
+++ b/PelicanTTS/SpeechHandlerPolly.cs
@@ -418,7 +418,7 @@ namespace PelicanTTS
                                     try { 
                                     Dialogue d = new Dialogue(text, Game1.getCharacterFromName(name));
                                     DialogueBox db = new DialogueBox(d);
-                                    List<string> dl = Helper.Reflection.GetPrivateValue<List<string>>(d, "dialogues");
+                                    List<string> dl = Helper.Reflection.GetField<List<string>>(d, "dialogues").GetValue();
                                     Monitor.Log("Dialog Length:" + dl.Count);
 
                                     while (dl.Count > 0)
@@ -457,7 +457,7 @@ namespace PelicanTTS
                                         }
                                         Monitor.Log(nextText);
                                         dl.RemoveAt(0);
-                                        Helper.Reflection.GetPrivateField<List<string>>(d, "dialogues").SetValue(dl);
+                                        Helper.Reflection.GetField<List<string>>(d, "dialogues").SetValue(dl);
                                     }
                                     }catch
                                     {

--- a/PelicanTTS/manifest.json
+++ b/PelicanTTS/manifest.json
@@ -1,14 +1,10 @@
 {
   "Name": "PelicanTTS",
   "Author": "Platonymous",
-  "Version": {
-    "MajorVersion": 1,
-    "MinorVersion": 6,
-    "PatchVersion": 1,
-    "Build": null
-  },
+  "Version": "1.6.1",
   "Description": "Text-To-Speech Mod",
   "UniqueID": "Platonymous.PelicanTTS",
   "EntryDll": "PelicanTTS.dll",
+  "MinimumApiVersion": "2.6-beta",
   "UpdateKeys": [ "Nexus:1079" ]
 }

--- a/PelicanTTS/packages.config
+++ b/PelicanTTS/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="AWSSDK.Core" version="3.3.18.2" targetFramework="net45" />
   <package id="AWSSDK.Polly" version="3.3.3.1" targetFramework="net45" />
-  <package id="Pathoschild.Stardew.ModBuildConfig" version="1.7.1" targetFramework="net45" />
+  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.1.0-beta-20180426" targetFramework="net45" />
 </packages>

--- a/PlanImporter/PlanImporter.csproj
+++ b/PlanImporter/PlanImporter.csproj
@@ -11,8 +11,6 @@
     <AssemblyName>PlanImporter</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -33,12 +31,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
@@ -57,14 +49,14 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <Analyzer Include="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-alpha20180410\analyzers\dotnet\cs\StardewModdingAPI.ModBuildConfig.Analyzer.dll" />
+    <Analyzer Include="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\analyzers\dotnet\cs\StardewModdingAPI.ModBuildConfig.Analyzer.dll" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-alpha20180410\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-alpha20180410\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
+  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-alpha20180410\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-alpha20180410\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
+    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
   </Target>
 </Project>

--- a/PlanImporter/manifest.json
+++ b/PlanImporter/manifest.json
@@ -1,14 +1,10 @@
 {
   "Name": "PlanImporter",
   "Author": "Platonymous",
-  "Version": {
-    "MajorVersion": 0,
-    "MinorVersion": 8,
-    "PatchVersion": 1,
-    "Build": null
-  },
+  "Version": "0.8.1",
   "Description": "Import plans from stardew.info.",
   "UniqueID": "Platonymous.PlanImporter",
   "EntryDll": "PlanImporter.dll",
+  "MinimumApiVersion": "2.6-beta",
   "UpdateKeys": [ "Nexus:2071" ]
 }

--- a/PlanImporter/packages.config
+++ b/PlanImporter/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.1.0-alpha20180410" targetFramework="net45" />
+  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.1.0-beta-20180426" targetFramework="net45" />
 </packages>

--- a/Portraiture/Portraiture.csproj
+++ b/Portraiture/Portraiture.csproj
@@ -55,13 +55,16 @@
       <Private>True</Private>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\analyzers\dotnet\cs\StardewModdingAPI.ModBuildConfig.Analyzer.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\deploy-mod.targets" />
-  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
+  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
+    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
   </Target>
 </Project>

--- a/Portraiture/manifest.json
+++ b/Portraiture/manifest.json
@@ -1,14 +1,10 @@
 {
   "Name": "Portraiture",
   "Author": "Platonymous",
-  "Version": {
-    "MajorVersion": 1,
-    "MinorVersion": 5,
-    "PatchVersion": 1,
-    "Build": null
-  },
+  "Version": "1.5.1",
   "Description": "Helper Mod for Portraits.",
   "UniqueID": "Platonymous.Portraiture",
   "EntryDll": "Portraiture.dll",
+  "MinimumApiVersion": "2.6-beta",
   "UpdateKeys": [ "Nexus:999" ]
 }

--- a/Portraiture/packages.config
+++ b/Portraiture/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net452" />
-  <package id="Pathoschild.Stardew.ModBuildConfig" version="1.7.1" targetFramework="net45" />
+  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.1.0-beta-20180426" targetFramework="net45" />
 </packages>

--- a/PyTK/PyTK.csproj
+++ b/PyTK/PyTK.csproj
@@ -35,6 +35,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ConsoleCommands\CCLua.cs" />

--- a/PyTK/PyTK.csproj
+++ b/PyTK/PyTK.csproj
@@ -11,9 +11,6 @@
     <AssemblyName>PyTK</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
-    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -37,12 +34,6 @@
       <HintPath>..\packages\MoonSharp.2.0.0.0\lib\net40-client\MoonSharp.Interpreter.dll</HintPath>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
@@ -124,13 +115,15 @@
       <Name>Harmony</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Analyzer Include="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\analyzers\dotnet\cs\StardewModdingAPI.ModBuildConfig.Analyzer.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.2\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.2\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
+  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.2\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.2\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
+    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
   </Target>
 </Project>

--- a/PyTK/PyUtils.cs
+++ b/PyTK/PyUtils.cs
@@ -62,7 +62,7 @@ namespace PyTK
             if (conditions.StartsWith("PC "))
                 result = checkPlayerConditions(conditions.Replace("PC ", ""));
             else
-                result = Helper.Reflection.GetMethod(Game1.currentLocation, "checkEventPrecondition").Invoke<int>(new object[] { "9999999/" + conditions }) != -1;
+                result = Helper.Reflection.GetMethod(Game1.currentLocation, "checkEventPrecondition").Invoke<int>("9999999/" + conditions) != -1;
 
             return result == comparer;
         }

--- a/PyTK/manifest.json
+++ b/PyTK/manifest.json
@@ -1,14 +1,10 @@
 {
   "Name": "PyTK",
   "Author": "Platonymous",
-  "Version": {
-    "MajorVersion": 0,
-    "MinorVersion": 8,
-    "PatchVersion": 6,
-    "Build": null
-  },
+  "Version": "0.8.6",
   "Description": "Platonymous Toolkit",
   "UniqueID": "Platonymous.Toolkit",
   "EntryDll": "PyTK.dll",
+  "MinimumApiVersion": "2.6-beta",
   "UpdateKeys": [ "Nexus:1726" ]
 }

--- a/PyTK/packages.config
+++ b/PyTK/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="MoonSharp" version="2.0.0.0" targetFramework="net45" />
-  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.0.2" targetFramework="net45" />
+  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.1.0-beta-20180426" targetFramework="net45" />
 </packages>

--- a/RingOfFire/RingOfFire.cs
+++ b/RingOfFire/RingOfFire.cs
@@ -522,7 +522,7 @@ namespace RingOfFire
             price = Convert.ToInt32(strArray[1]);
             indexInTileSheet = 517;
             uniqueID = Game1.year + Game1.dayOfMonth + Game1.timeOfDay + this.indexInTileSheet + Game1.player.getTileX() + (int)Game1.stats.MonstersKilled + (int)Game1.stats.itemsCrafted;
-            RingOfFireMod.helper.Reflection.GetPrivateMethod(this, "loadDisplayFields").Invoke();
+            RingOfFireMod.helper.Reflection.GetMethod(this, "loadDisplayFields").Invoke();
             build();
         }
     }

--- a/RingOfFire/RingOfFire.csproj
+++ b/RingOfFire/RingOfFire.csproj
@@ -68,13 +68,16 @@
       <Private>False</Private>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\analyzers\dotnet\cs\StardewModdingAPI.ModBuildConfig.Analyzer.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\deploy-mod.targets" />
-  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
+  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
+    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
   </Target>
 </Project>

--- a/RingOfFire/RingOfFireMod.cs
+++ b/RingOfFire/RingOfFireMod.cs
@@ -44,8 +44,8 @@ namespace RingOfFire
             if (Game1.activeClickableMenu is ShopMenu)
             {
                 ShopMenu shop = (ShopMenu)Game1.activeClickableMenu;
-                Dictionary<Item, int[]> items = Helper.Reflection.GetPrivateValue<Dictionary<Item, int[]>>(shop, "itemPriceAndStock");
-                List<Item> selling = Helper.Reflection.GetPrivateValue<List<Item>>(shop, "forSale");
+                Dictionary<Item, int[]> items = Helper.Reflection.GetField<Dictionary<Item, int[]>>(shop, "itemPriceAndStock").GetValue();
+                List<Item> selling = Helper.Reflection.GetField<List<Item>>(shop, "forSale").GetValue();
 
                 if (shop.portraitPerson == Game1.getCharacterFromName("Marlon") )
                 {

--- a/RingOfFire/manifest.json
+++ b/RingOfFire/manifest.json
@@ -1,19 +1,15 @@
 {
   "Name": "Ring Of Fire",
   "Author": "Platonymous",
-  "Version": {
-    "MajorVersion": 1,
-    "MinorVersion": 0,
-    "PatchVersion": 1,
-    "Build": null
-  },
+  "Version": "1.0.1",
   "Description": "Unleash the Flames",
   "UniqueID": "Platonymous.RingOfFire",
   "EntryDll": "RingOfFire.dll",
+  "MinimumApiVersion": "2.6-beta",
+  "UpdateKeys": [ "Nexus:1166" ],
   "Dependencies": [
     {
       "UniqueID": "Platonymous.CustomElementHandler"
     }
-  ],
-  "UpdateKeys": [ "Nexus:1166" ]
+  ]
 }

--- a/RingOfFire/packages.config
+++ b/RingOfFire/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Pathoschild.Stardew.ModBuildConfig" version="1.7.1" targetFramework="net45" />
+  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.1.0-beta-20180426" targetFramework="net45" />
 </packages>

--- a/Screener/Screener.csproj
+++ b/Screener/Screener.csproj
@@ -11,8 +11,6 @@
     <AssemblyName>Screener</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -51,20 +49,20 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <Analyzer Include="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-alpha20180410\analyzers\dotnet\cs\StardewModdingAPI.ModBuildConfig.Analyzer.dll" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\..\Harmony\Harmony\Harmony.csproj">
       <Project>{69aee16a-b6e7-4642-8081-3928b32455df}</Project>
       <Name>Harmony</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\analyzers\dotnet\cs\StardewModdingAPI.ModBuildConfig.Analyzer.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-alpha20180410\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-alpha20180410\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
+  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-alpha20180410\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-alpha20180410\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
+    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
   </Target>
 </Project>

--- a/Screener/manifest.json
+++ b/Screener/manifest.json
@@ -1,13 +1,10 @@
 {
   "Name": "Screener",
   "Author": "Platonymous",
-  "Version": {
-    "MajorVersion": 1,
-    "MinorVersion": 0,
-    "PatchVersion": 0,
-    "Build": null
-  },
+  "Version": "1.0.0",
   "Description": "Take screenshots from within the game",
   "UniqueID": "Platonymous.Screener",
-  "EntryDll": "Screener.dll"
+  "EntryDll": "Screener.dll",
+  "MinimumApiVersion": "2.6-beta",
+  "UpdateKeys": []
 }

--- a/Screener/packages.config
+++ b/Screener/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.1.0-alpha20180410" targetFramework="net45" />
+  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.1.0-beta-20180426" targetFramework="net45" />
 </packages>

--- a/SeedBag/SeedBag.csproj
+++ b/SeedBag/SeedBag.csproj
@@ -60,13 +60,16 @@
       <Private>False</Private>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\analyzers\dotnet\cs\StardewModdingAPI.ModBuildConfig.Analyzer.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\deploy-mod.targets" />
-  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
+  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
+    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
   </Target>
 </Project>

--- a/SeedBag/manifest.json
+++ b/SeedBag/manifest.json
@@ -1,19 +1,15 @@
 {
   "Name": "Seed Bag",
   "Author": "Platonymous",
-  "Version": {
-    "MajorVersion": 1,
-    "MinorVersion": 2,
-    "PatchVersion": 0,
-    "Build": null
-  },
+  "Version": "1.2.0",
   "Description": "Adds a Seed Bag to the Game",
   "UniqueID": "Platonymous.SeedBag",
   "EntryDll": "SeedBag.dll",
+  "MinimumApiVersion": "2.6-beta",
+  "UpdateKeys": [ "Nexus:1133" ],
   "Dependencies": [
     {
       "UniqueID": "Platonymous.Toolkit"
     }
-  ],
-  "UpdateKeys": [ "Nexus:1133" ]
+  ]
 }

--- a/SeedBag/packages.config
+++ b/SeedBag/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Pathoschild.Stardew.ModBuildConfig" version="1.7.1" targetFramework="net45" />
+  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.1.0-beta-20180426" targetFramework="net45" />
 </packages>

--- a/SleepWorker/SleepWorker.csproj
+++ b/SleepWorker/SleepWorker.csproj
@@ -11,8 +11,6 @@
     <AssemblyName>SleepWorker</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -33,12 +31,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
@@ -50,21 +42,21 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <Analyzer Include="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-alpha20180410\analyzers\dotnet\cs\StardewModdingAPI.ModBuildConfig.Analyzer.dll" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\PyTK\PyTK.csproj">
       <Project>{a8e6272f-a6a1-4bfe-ba8f-021f63596987}</Project>
       <Name>PyTK</Name>
       <Private>False</Private>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\analyzers\dotnet\cs\StardewModdingAPI.ModBuildConfig.Analyzer.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-alpha20180410\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-alpha20180410\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
+  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-alpha20180410\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-alpha20180410\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
+    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
   </Target>
 </Project>

--- a/SleepWorker/manifest.json
+++ b/SleepWorker/manifest.json
@@ -1,19 +1,15 @@
 {
   "Name": "SleepWorker",
   "Author": "Platonymous",
-  "Version": {
-    "MajorVersion": 1,
-    "MinorVersion": 0,
-    "PatchVersion": 1,
-    "Build": null
-  },
+  "Version": "1.0.1",
   "Description": "Skips time before you sleep",
   "UniqueID": "Platonymous.SleepWorker",
   "EntryDll": "SleepWorker.dll",
+  "MinimumApiVersion": "2.6-beta",
+  "UpdateKeys": [ "Nexus:2062" ],
   "Dependencies": [
     {
       "UniqueID": "Platonymous.Toolkit"
     }
-  ],
-  "UpdateKeys": [ "Nexus:2062" ]
+  ]
 }

--- a/SleepWorker/packages.config
+++ b/SleepWorker/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.1.0-alpha20180410" targetFramework="net45" />
+  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.1.0-beta-20180426" targetFramework="net45" />
 </packages>

--- a/Snake/Snake.csproj
+++ b/Snake/Snake.csproj
@@ -11,8 +11,6 @@
     <AssemblyName>Snake</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -33,12 +31,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
@@ -56,9 +48,6 @@
   <ItemGroup>
     <None Include="manifest.json" />
     <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <Analyzer Include="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-alpha20180410\analyzers\dotnet\cs\StardewModdingAPI.ModBuildConfig.Analyzer.dll" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\PyTK\PyTK.csproj">
@@ -84,12 +73,15 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\analyzers\dotnet\cs\StardewModdingAPI.ModBuildConfig.Analyzer.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-alpha20180410\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-alpha20180410\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
+  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-alpha20180410\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-alpha20180410\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
+    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
   </Target>
 </Project>

--- a/Snake/manifest.json
+++ b/Snake/manifest.json
@@ -1,15 +1,11 @@
 {
   "Name": "Snake",
   "Author": "Platonymous",
-  "Version": {
-    "MajorVersion": 1,
-    "MinorVersion": 0,
-    "PatchVersion": 0,
-    "Build": null
-  },
+  "Version": "1.0.0",
   "Description": "Play Snake.",
   "UniqueID": "Platonymous.Snake",
   "EntryDll": "Snake.dll",
+  "MinimumApiVersion": "2.6-beta",
   "UpdateKeys": [ "Nexus:2048" ],
   "Dependencies": [
     {

--- a/Snake/packages.config
+++ b/Snake/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.1.0-alpha20180410" targetFramework="net45" />
+  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.1.0-beta-20180426" targetFramework="net45" />
 </packages>

--- a/Speedster/Speedster.csproj
+++ b/Speedster/Speedster.csproj
@@ -59,13 +59,16 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\analyzers\dotnet\cs\StardewModdingAPI.ModBuildConfig.Analyzer.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\deploy-mod.targets" />
-  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
+  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
+    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
   </Target>
 </Project>

--- a/Speedster/SpeedsterMod.cs
+++ b/Speedster/SpeedsterMod.cs
@@ -76,8 +76,8 @@ namespace Speedster
             if(Game1.activeClickableMenu is ShopMenu)
             {
                 ShopMenu shop = (ShopMenu)Game1.activeClickableMenu;
-                Dictionary<Item, int[]> items = Helper.Reflection.GetPrivateValue<Dictionary<Item, int[]>>(shop, "itemPriceAndStock");
-                List<Item> selling = Helper.Reflection.GetPrivateValue<List<Item>>(shop, "forSale");
+                Dictionary<Item, int[]> items = Helper.Reflection.GetField<Dictionary<Item, int[]>>(shop, "itemPriceAndStock").GetValue();
+                List<Item> selling = Helper.Reflection.GetField<List<Item>>(shop, "forSale").GetValue();
 
                 if (items.Keys.FirstOrDefault<Item>() is Hat)
                 {

--- a/Speedster/manifest.json
+++ b/Speedster/manifest.json
@@ -1,19 +1,15 @@
 {
   "Name": "Speedster",
   "Author": "Platonymous",
-  "Version": {
-    "MajorVersion": 1,
-    "MinorVersion": 3,
-    "PatchVersion": 1,
-    "Build": null
-  },
+  "Version": "1.3.1",
   "Description": "To the outside world you are just an ordinary farmer, but secretly...",
   "UniqueID": "Platonymous.Speedster",
   "EntryDll": "Speedster.dll",
+  "MinimumApiVersion": "2.6-beta",
+  "UpdateKeys": [ "Nexus:1102" ],
   "Dependencies": [
     {
       "UniqueID": "Platonymous.CustomElementHandler"
     }
-  ],
-  "UpdateKeys": [ "Nexus:1102" ]
+  ]
 }

--- a/Speedster/packages.config
+++ b/Speedster/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Pathoschild.Stardew.ModBuildConfig" version="1.7.1" targetFramework="net45" />
+  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.1.0-beta-20180426" targetFramework="net45" />
 </packages>

--- a/Sprinkles/Sprinkles.csproj
+++ b/Sprinkles/Sprinkles.csproj
@@ -11,8 +11,6 @@
     <AssemblyName>Sprinkles</AssemblyName>
     <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -33,12 +31,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
@@ -49,12 +41,15 @@
     <None Include="manifest.json" />
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\analyzers\dotnet\cs\StardewModdingAPI.ModBuildConfig.Analyzer.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.2\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.2\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
+  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.2\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.2\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
+    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
   </Target>
 </Project>

--- a/Sprinkles/manifest.json
+++ b/Sprinkles/manifest.json
@@ -1,13 +1,10 @@
 {
   "Name": "Sprinkles",
   "Author": "Platonymous",
-  "Version": {
-    "MajorVersion": 1,
-    "MinorVersion": 2,
-    "PatchVersion": 0,
-    "Build": null
-  },
+  "Version": "1.2.0",
   "Description": "Activate Sprinklers in current location on click",
   "UniqueID": "Platonymous.Sprinkles",
-  "EntryDll": "Sprinkles.dll"
+  "EntryDll": "Sprinkles.dll",
+  "MinimumApiVersion": "2.6-beta",
+  "UpdateKeys": []
 }

--- a/Sprinkles/packages.config
+++ b/Sprinkles/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.0.2" targetFramework="net462" />
+  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.1.0-beta-20180426" targetFramework="net462" />
 </packages>

--- a/SwimSuit/SwimSuit.csproj
+++ b/SwimSuit/SwimSuit.csproj
@@ -42,13 +42,16 @@
     <None Include="manifest.json" />
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\analyzers\dotnet\cs\StardewModdingAPI.ModBuildConfig.Analyzer.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\deploy-mod.targets" />
-  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
+  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
+    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
   </Target>
 </Project>

--- a/SwimSuit/manifest.json
+++ b/SwimSuit/manifest.json
@@ -1,14 +1,10 @@
 {
   "Name": "Swim Suit",
   "Author": "Platonymous",
-  "Version": {
-    "MajorVersion": 0,
-    "MinorVersion": 5,
-    "PatchVersion": 1,
-    "Build": null
-  },
+  "Version": "0.5.1",
   "Description": "Swim almost anywhere",
   "UniqueID": "Platonymous.SwimSuit",
   "EntryDll": "SwimSuit.dll",
+  "MinimumApiVersion": "2.6-beta",
   "UpdateKeys": [ "Nexus:1215" ]
 }

--- a/SwimSuit/packages.config
+++ b/SwimSuit/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Pathoschild.Stardew.ModBuildConfig" version="1.7.1" targetFramework="net45" />
+  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.1.0-beta-20180426" targetFramework="net45" />
 </packages>

--- a/TMXLoader/TMXLoader.csproj
+++ b/TMXLoader/TMXLoader.csproj
@@ -11,8 +11,6 @@
     <AssemblyName>TMXLoader</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -33,12 +31,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
@@ -90,12 +82,15 @@
     <Content Include="Examples\UlithiumDragon.JungleTemple\winter_JungleTempleTileSheet.png" />
     <Content Include="Examples\UlithiumDragon.JungleTemple\WizardHouseTiles.png" />
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\analyzers\dotnet\cs\StardewModdingAPI.ModBuildConfig.Analyzer.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.2\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.2\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
+  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.2\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.2\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
+    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
   </Target>
 </Project>

--- a/TMXLoader/manifest.json
+++ b/TMXLoader/manifest.json
@@ -1,15 +1,11 @@
 {
   "Name": "TMXLoader",
   "Author": "Platonymous",
-  "Version": {
-    "MajorVersion": 1,
-    "MinorVersion": 2,
-    "PatchVersion": 1,
-    "Build": null
-  },
+  "Version": "1.2.1",
   "Description": "Load TMX Maps into the Game",
   "UniqueID": "Platonymous.TMXLoader",
   "EntryDll": "TMXLoader.dll",
+  "MinimumApiVersion": "2.6-beta",
   "UpdateKeys": [ "Nexus:1820" ],
   "Dependencies": [
     {

--- a/TMXLoader/packages.config
+++ b/TMXLoader/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.0.2" targetFramework="net45" />
+  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.1.0-beta-20180426" targetFramework="net45" />
 </packages>

--- a/Visualize/Visualize.csproj
+++ b/Visualize/Visualize.csproj
@@ -11,9 +11,6 @@
     <AssemblyName>Visualize</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
-    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -34,12 +31,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
@@ -63,12 +54,15 @@
       <Private>True</Private>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\analyzers\dotnet\cs\StardewModdingAPI.ModBuildConfig.Analyzer.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.2\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.2\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
+  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.2\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.2\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
+    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
   </Target>
 </Project>

--- a/Visualize/manifest.json
+++ b/Visualize/manifest.json
@@ -1,14 +1,10 @@
 {
   "Name": "Visualize",
   "Author": "Platonymous",
-  "Version": {
-    "MajorVersion": 1,
-    "MinorVersion": 4,
-    "PatchVersion": 0,
-    "Build": null
-  },
+  "Version": "1.4.0",
   "Description": "Mod for Visual Effects",
   "UniqueID": "Platonymous.Visualize",
   "EntryDll": "Visualize.dll",
+  "MinimumApiVersion": "2.6-beta",
   "UpdateKeys": [ "Nexus:1704" ]
 }

--- a/Visualize/packages.config
+++ b/Visualize/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.0.2" targetFramework="net462" />
+  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.1.0-beta-20180426" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
This pull request contains the **initial changes** for the migration to Stardew Valley 1.3. (With the update coming very soon, I'm mainly focusing on the mods I can update quickly; but at least this will reduce your work slightly.)

This pull request...
* Updates the mod build package to support Stardew Valley 1.3.
* Standardises the manifests, fixes a missing update key, and sets the minimum SMAPI version to 2.6 beta for all mods.
* Updates the reflection API (the deprecated methods were removed in SMAPI 2.6).