### PR TITLE
Update input events for the upcoming SMAPI 3.0

### DIFF
--- a/ArcadePong/ArcadePongMod.cs
+++ b/ArcadePong/ArcadePongMod.cs
@@ -18,7 +18,7 @@ namespace ArcadePong
         internal static IModHelper pongHelper;
         internal static IMonitor monitor;
         internal static Mod pong;
-        internal static List<EventHandler<EventArgsKeyPressed>> keyEvents = new List<EventHandler<EventArgsKeyPressed>>();
+        internal static List<EventHandler<ButtonPressedEventArgs>> keyEvents = new List<EventHandler<ButtonPressedEventArgs>>();
         internal CustomObjectData pdata; 
 
 
@@ -29,8 +29,8 @@ namespace ArcadePong
             SaveEvents.AfterLoad += (o, e) => setup();
             SaveEvents.AfterReturnToTitle += (s, o) =>
             {
-                foreach (EventHandler<EventArgsKeyPressed> a in keyEvents)
-                    ControlEvents.KeyPressed -= a;
+                foreach (EventHandler<ButtonPressedEventArgs> a in keyEvents)
+                    helper.Events.Input.ButtonPressed -= a;
             };
             pdata = new CustomObjectData("Pong", "Pong/0/-300/Crafting -9/Play 'Pong by Cat' at home!/true/true/0/Pong", Game1.bigCraftableSpriteSheet.getTile(159, 16, 32).setSaturation(0).setLight(130), Color.Yellow, bigCraftable: true, type: typeof(PongMachine));
            
@@ -41,13 +41,13 @@ namespace ArcadePong
             new InventoryItem(pdata.getObject(), 0, 1).addToFurnitureCatalogue();
             PongMinigame.game = Helper.Reflection.GetField<object>(pong, "game").GetValue();
             pongHelper = (IModHelper)typeof(Mod).GetProperty("Helper", BindingFlags.Public | BindingFlags.Instance).GetValue(pong);
-            keyEvents.AddOrReplace(Keys.Space.onPressed(() =>
+            keyEvents.AddOrReplace(SButton.Space.onPressed(() =>
             {
                 if (Game1.currentMinigame is PongMinigame p)
                     Helper.Reflection.GetMethod(PongMinigame.game, "Start").Invoke();
             }));
 
-            keyEvents.AddOrReplace(Keys.Escape.onPressed(() =>
+            keyEvents.AddOrReplace(SButton.Escape.onPressed(() =>
             {
                 if (Game1.currentMinigame is PongMinigame p)
                     if (Helper.Reflection.GetMethod(PongMinigame.game, "HasStarted").Invoke<bool>())
@@ -58,7 +58,7 @@ namespace ArcadePong
                         Game1.options.zoomLevel = PongMachine.zoom;
                     }
             }));
-            keyEvents.AddOrReplace(Keys.P.onPressed(() =>
+            keyEvents.AddOrReplace(SButton.P.onPressed(() =>
             {
                 if (Game1.currentMinigame is PongMinigame p)
                     Helper.Reflection.GetMethod(PongMinigame.game, "TogglePaused").Invoke();

--- a/CustomFarmingRedux/CustomFarmingReduxMod.cs
+++ b/CustomFarmingRedux/CustomFarmingReduxMod.cs
@@ -15,7 +15,6 @@ using SObject = StardewValley.Object;
 using Microsoft.Xna.Framework;
 using System;
 using StardewValley.Tools;
-using Microsoft.Xna.Framework.Input;
 using PyTK.Lua;
 using Microsoft.Xna.Framework.Graphics;
 

--- a/CustomShirts/Config.cs
+++ b/CustomShirts/Config.cs
@@ -1,12 +1,12 @@
-﻿using Microsoft.Xna.Framework.Input;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
+using StardewModdingAPI;
 
 namespace CustomShirts
 {
     class Config
     {
         public string ShirtId { get; set; } = "none";
-        public Keys SwitchKey { get; set; } = Keys.J;
+        public SButton SwitchKey { get; set; } = SButton.J;
         public List<SavedShirt> SavedShirts { get; set; } = new List<SavedShirt>();
 
         public Config()

--- a/CustomShirts/CustomShirtsMod.cs
+++ b/CustomShirts/CustomShirtsMod.cs
@@ -119,7 +119,7 @@ namespace CustomShirts
 
             loadContentPacks();
 
-            if(config.SwitchKey != Keys.Escape)
+            if(config.SwitchKey != SButton.Escape)
                 config.SwitchKey.onPressed(() => Game1.activeClickableMenu = new CharacterCustomization(CharacterCustomization.Source.Wizard));
 
             GameEvents.QuarterSecondTick += (s, e) =>

--- a/JoJaBan/JoJaBanMod.cs
+++ b/JoJaBan/JoJaBanMod.cs
@@ -12,7 +12,6 @@ using PyTK.Tiled;
 using System.IO;
 using xTile;
 using System;
-using Microsoft.Xna.Framework.Input;
 
 namespace JoJaBan
 {
@@ -44,7 +43,7 @@ namespace JoJaBan
             Texture2D townInterior = Helper.Content.Load<Texture2D>(@"Maps/townInterior", ContentSource.GameContent);
             boxTexture = townInterior.getArea(new Rectangle(304, 1024, 16, 32));
             boxData = new CustomObjectData("JoJa Box", "JoJa Box/0/-300/Crafting -9/JoJa Box/true/true/0/JoJa Box", boxTexture, Color.White, bigCraftable: true, type:typeof(JoJaBox));
-            ControlEvents.KeyPressed += ControlEvents_KeyPressed;
+            helper.Events.Input.ButtonPressed += OnButtonPressed;
             SaveEvents.AfterLoad += (o, e) => addToCatalogue();
         }
 
@@ -84,9 +83,9 @@ namespace JoJaBan
             return true;
         }
 
-        private static void ControlEvents_KeyPressed(object sender, EventArgsKeyPressed e)
+        private static void OnButtonPressed(object sender, ButtonPressedEventArgs e)
         {
-            if (e.KeyPressed == Keys.Escape && Game1.currentLocation is GameLocation gl && gl.Name.StartsWith("JoJaBanLevel"))
+            if (e.Button == SButton.Escape && Game1.currentLocation is GameLocation gl && gl.Name.StartsWith("JoJaBanLevel"))
             {
                 resetLevel(Game1.currentLocation);
                 loadLevel(currentLevel);

--- a/MuliplayerTweaks/MultiplayerTweaksMod.cs
+++ b/MuliplayerTweaks/MultiplayerTweaksMod.cs
@@ -34,7 +34,7 @@ namespace MuliplayerTweaks
                 overflow = config.LimitPositonSyncOverflow;
             }
 
-            /*Keys.U.onPressed( () => 
+            /*SButton.U.onPressed( () => 
             {
                 Game1.game1.IsFixedTimeStep = false;
                 Game1.debugMode = true;

--- a/Notes/NotesMod.cs
+++ b/Notes/NotesMod.cs
@@ -4,10 +4,7 @@ using StardewValley;
 using StardewValley.Menus;
 using StardewModdingAPI;
 using StardewModdingAPI.Events;
-using PyTK.Extensions;
 using PyTK.CustomElementHandler;
-using System.Collections.Generic;
-using System.Linq;
 using StardewValley.Objects;
 
 namespace Notes
@@ -27,7 +24,7 @@ namespace Notes
             NoteInfo = i18n.Get("notes.note.info");
             initNotes();
 
-            ControlEvents.MouseChanged += (s,e) => checkForSigns();
+            helper.Events.Input.CursorMoved += (s,e) => checkForSigns(e.NewPosition);
             GraphicsEvents.OnPostRenderEvent += GraphicsEvents_OnPostRenderEvent;
         }
 
@@ -38,14 +35,12 @@ namespace Notes
             IClickableMenu.drawHoverText(Game1.spriteBatch, displayNote, Game1.smallFont, 0, 0, -1);
         }
 
-        public static void checkForSigns()
+        public static void checkForSigns(ICursorPosition cursor)
         {
             if (Game1.activeClickableMenu != null)
                 return;
-            int xTile = (Game1.viewport.X + Game1.getOldMouseX()) / 64;
-            int yTile = (Game1.viewport.Y + Game1.getOldMouseY()) / 64;
-            Vector2 oneDown = new Vector2(xTile, yTile + 1);
-            Vector2 pos = new Vector2(xTile, yTile);
+            Vector2 pos = cursor.Tile;
+            Vector2 oneDown = new Vector2(pos.X, pos.Y + 1);
             if (Game1.currentLocation != null
                 && Game1.currentLocation.objects.ContainsKey(pos)
                 && Game1.currentLocation.objects[pos] is Sign sign

--- a/PelicanTTS/PelicanTTSMod.cs
+++ b/PelicanTTS/PelicanTTSMod.cs
@@ -131,15 +131,15 @@ namespace PelicanTTS
 
 
 
-        private void ControlEvents_KeyPressed(object sender, EventArgsKeyPressed e)
+        private void OnButtonPressed(object sender, ButtonPressedEventArgs e)
         {
             ModConfig config = Helper.ReadConfig<ModConfig>();
             if (config.polly == "off" || !pollySetup)
             {
-                if (e.KeyPressed == Keys.F7)
+                if (e.Button == SButton.F7)
                     SpeechHandler.showInstalledVoices();
 
-                if (e.KeyPressed == Keys.F8)
+                if (e.Button == SButton.F8)
                     SpeechHandler.demoVoices();
             }
         }
@@ -147,7 +147,7 @@ namespace PelicanTTS
         private void SaveEvents_AfterReturnToTitle(object sender, EventArgs e)
         {
             GameEvents.OneSecondTick -= GameEvents_OneSecondTick;
-            ControlEvents.KeyPressed -= ControlEvents_KeyPressed;
+            Helper.Events.Input.ButtonPressed -= OnButtonPressed;
             ModConfig config = Helper.ReadConfig<ModConfig>();
             if (config.polly == "on" && pollySetup)
                 SpeechHandlerPolly.stop();
@@ -178,13 +178,12 @@ namespace PelicanTTS
             {
                 SpeechHandlerPolly.Monitor = Monitor;
                 SpeechHandlerPolly.start(Helper);
-                
             }
             else
                 SpeechHandler.start(Helper,Monitor);
-            
+
             GameEvents.OneSecondTick += GameEvents_OneSecondTick;
-            ControlEvents.KeyPressed += ControlEvents_KeyPressed;
+            Helper.Events.Input.ButtonPressed += OnButtonPressed;
         }
 
 

--- a/PelicanTTS/SpeechHandlerPolly.cs
+++ b/PelicanTTS/SpeechHandlerPolly.cs
@@ -78,14 +78,12 @@ namespace PelicanTTS
 
             MenuEvents.MenuClosed += MenuEvents_MenuClosed;
 
-            //ControlEvents.KeyPressed += ControlEvents_KeyPressed;
-
+            //h.Events.Input.ButtonPressed += OnButtonPressed;
         }
 
-        private static void ControlEvents_KeyPressed(object sender, EventArgsKeyPressed e)
+        private static void OnButtonPressed(object sender, ButtonPressedEventArgs e)
         {
-            
-            if (e.KeyPressed.ToString() == "K")
+            if (e.Button == SButton.K)
             {
                 gThread = new Thread(generateAllDialogs);
                 gThread.Start();

--- a/Portraiture/PConfig.cs
+++ b/Portraiture/PConfig.cs
@@ -1,10 +1,10 @@
-﻿using Microsoft.Xna.Framework.Input;
+﻿using StardewModdingAPI;
 
 namespace Portraiture
 {
     class PConfig
     {
-        public Keys changeKey { get; set; } = Keys.P;
+        public SButton changeKey { get; set; } = SButton.P;
         public string active { get; set; } = "none";
     }
 }

--- a/Portraiture/PortraitureMod.cs
+++ b/Portraiture/PortraitureMod.cs
@@ -45,7 +45,7 @@ namespace Portraiture
             GameEvents.FourthUpdateTick -= GameEvents_FourthUpdateTick;
             MenuEvents.MenuClosed -= MenuEvents_MenuClosed;
             MenuEvents.MenuChanged -= MenuEvents_MenuChanged;
-            ControlEvents.KeyPressed -= ControlEvents_KeyPressed;
+            helper.Events.Input.ButtonPressed -= OnButtonPressed;
         }
 
         public static void log (string text)
@@ -59,7 +59,7 @@ namespace Portraiture
             GameEvents.FourthUpdateTick += GameEvents_FourthUpdateTick;
             MenuEvents.MenuClosed += MenuEvents_MenuClosed;
             MenuEvents.MenuChanged += MenuEvents_MenuChanged;
-            ControlEvents.KeyPressed += ControlEvents_KeyPressed;
+            helper.Events.Input.ButtonPressed += OnButtonPressed;
         }
 
         private void GameEvents_FourthUpdateTick(object sender, System.EventArgs e)
@@ -90,10 +90,9 @@ namespace Portraiture
                 Utility.drawTextWithShadow(b, activeFolderText, Game1.smallFont, new Vector2(displayBoxPos.X + ((displayBoxWidth - textlength) / 2), Game1.pixelZoom + displayBoxPos.Y + ((displayBoxHeight - textheight) / 2)), Game1.textColor);
         }
 
-        private void ControlEvents_KeyPressed(object sender, EventArgsKeyPressed e)
+        private void OnButtonPressed(object sender, ButtonPressedEventArgs e)
         {
-            
-            if (e.KeyPressed == config.changeKey && Game1.activeClickableMenu is DialogueBox d && d.isPortraitBox() && Game1.currentSpeaker is NPC cs)
+            if (e.Button == config.changeKey && Game1.activeClickableMenu is DialogueBox d && d.isPortraitBox() && Game1.currentSpeaker is NPC cs)
             {
                 if (d.width < 107 * Game1.pixelZoom * 3 / 2 || Helper.Reflection.GetField<bool>(d, "transitioning").GetValue() || Helper.Reflection.GetField<bool>(d, "isQuestion").GetValue())
                     return;

--- a/PyTK/Extensions/PyEvents.cs
+++ b/PyTK/Extensions/PyEvents.cs
@@ -4,19 +4,18 @@ using SObject = StardewValley.Object;
 using StardewValley.Menus;
 using StardewValley.Objects;
 using System;
-using Microsoft.Xna.Framework.Input;
 using StardewValley.TerrainFeatures;
 using StardewValley;
 using PyTK.Types;
 using System.Collections.Generic;
 using System.Linq;
-using System.Collections.Specialized;
 using Microsoft.Xna.Framework;
 
 namespace PyTK.Extensions
 {
     public static class PyEvents
     {
+        private static IModEvents Events { get; } = PyTKMod._events;
         internal static IModHelper Helper { get; } = PyTKMod._helper;
         internal static IMonitor Monitor { get; } = PyTKMod._monitor;
 
@@ -413,236 +412,234 @@ namespace PyTK.Extensions
             return d;
         }
 
-
-
         /* Input */
 
-        /// <summary>Wraps the the method so it only executes if a specific Key is pressed and adds it to ControlEvents.KeyPressed.</summary>
+        /// <summary>Wraps the the method so it only executes if a specific Key is pressed and adds it to <see cref="IInputEvents.ButtonPressed"/>.</summary>
         /// <returns>Returns the wrapped method.</returns>
-        public static EventHandler<EventArgsKeyPressed> onPressed(this Keys k, EventHandler<EventArgsKeyPressed> handler)
+        public static EventHandler<ButtonPressedEventArgs> onPressed(this SButton k, EventHandler<ButtonPressedEventArgs> handler)
         {
-            EventHandler<EventArgsKeyPressed> d = delegate (object sender, EventArgsKeyPressed e)
+            EventHandler<ButtonPressedEventArgs> d = delegate (object sender, ButtonPressedEventArgs e)
             {
-                if (e.KeyPressed == k)
+                if (e.Button == k)
                     handler.Invoke(sender, e);
             };
 
-            ControlEvents.KeyPressed += d;
+            PyEvents.Events.Input.ButtonPressed += d;
 
             return d;
         }
 
-        /// <summary>Wraps the the method so it only executes if a specific Key is pressed and adds it to ControlEvents.KeyPressed.</summary>
+        /// <summary>Wraps the the method so it only executes if a specific Key is pressed and adds it to <see cref="IInputEvents.ButtonPressed"/>.</summary>
         /// <returns>Returns the wrapped method.</returns>
-        public static EventHandler<EventArgsKeyPressed> onPressed(this Keys k, Action action)
+        public static EventHandler<ButtonPressedEventArgs> onPressed(this SButton k, Action action)
         {
-            EventHandler<EventArgsKeyPressed> d = delegate (object sender, EventArgsKeyPressed e)
+            EventHandler<ButtonPressedEventArgs> d = delegate (object sender, ButtonPressedEventArgs e)
             {
-                if (e.KeyPressed == k)
+                if (e.Button == k)
                     action.Invoke();
             };
 
-            ControlEvents.KeyPressed += d;
+            PyEvents.Events.Input.ButtonPressed += d;
 
             return d;
         }
 
-        /// <summary>Wraps the the method so it only executes if the player clicks on the specified tileposition and adds it to InputEvents.ButtonPressed.</summary>
+        /// <summary>Wraps the the method so it only executes if the player clicks on the specified tileposition and adds it to <see cref="IInputEvents.ButtonPressed"/>.</summary>
         /// <returns>Returns the wrapped method.</returns>
-        public static EventHandler<EventArgsInput> onClick(this ButtonClick t, TileLocationSelector tile, Action<Vector2> handler)
+        public static EventHandler<ButtonPressedEventArgs> onClick(this ButtonClick t, TileLocationSelector tile, Action<Vector2> handler)
         {
-            EventHandler<EventArgsInput> d = delegate (object sender, EventArgsInput e)
+            EventHandler<ButtonPressedEventArgs> d = delegate (object sender, ButtonPressedEventArgs e)
             {
-                bool isButton = t.Equals(ButtonClick.UseToolButton) ? e.IsUseToolButton : e.IsActionButton;
+                bool isButton = t.Equals(ButtonClick.UseToolButton) ? e.Button.IsUseToolButton() : e.Button.IsActionButton();
                 if (isButton && Game1.currentLocation is GameLocation location && tile.predicate(location,location.getTileAtMousePosition()))
                     handler.Invoke(location.getTileAtMousePosition());
             };
 
-            InputEvents.ButtonPressed += d;
+            PyEvents.Events.Input.ButtonPressed += d;
             return d;
         }
 
-        /// <summary>Wraps the the method so it only executes if the player clicks on the specified on a position that matches the predicate adds it to InputEvents.ButtonPressed.</summary>
+        /// <summary>Wraps the the method so it only executes if the player clicks on the specified on a position that matches the predicate adds it to <see cref="IInputEvents.ButtonPressed"/>.</summary>
         /// <returns>Returns the wrapped method.</returns>
-        public static EventHandler<EventArgsInput> onClick(this ButtonClick t, Func<Point,bool> predicate, Action<Point> handler)
+        public static EventHandler<ButtonPressedEventArgs> onClick(this ButtonClick t, Func<Point,bool> predicate, Action<Point> handler)
         {
-            EventHandler<EventArgsInput> d = delegate (object sender, EventArgsInput e)
+            EventHandler<ButtonPressedEventArgs> d = delegate (object sender, ButtonPressedEventArgs e)
             {
-                bool isButton = t.Equals(ButtonClick.UseToolButton) ? e.IsUseToolButton : e.IsActionButton;
+                bool isButton = t.Equals(ButtonClick.UseToolButton) ? e.Button.IsUseToolButton() : e.Button.IsActionButton();
                 Point mousePosition = Game1.getMousePosition();
                 if (isButton && predicate.Invoke(mousePosition))
                     handler.Invoke(mousePosition);
             };
 
-            InputEvents.ButtonPressed += d;
+            PyEvents.Events.Input.ButtonPressed += d;
             return d;
         }
 
-        /// <summary>Wraps the the method so it only executes if the player clicks on the screen position and adds it to InputEvents.ButtonPressed.</summary>
+        /// <summary>Wraps the the method so it only executes if the player clicks on the screen position and adds it to <see cref="IInputEvents.ButtonPressed"/>.</summary>
         /// <returns>Returns the wrapped method.</returns>
-        public static EventHandler<EventArgsInput> onClick(this ButtonClick t, Point position, Action<Point> handler)
+        public static EventHandler<ButtonPressedEventArgs> onClick(this ButtonClick t, Point position, Action<Point> handler)
         {
-            EventHandler<EventArgsInput> d = delegate (object sender, EventArgsInput e)
+            EventHandler<ButtonPressedEventArgs> d = delegate (object sender, ButtonPressedEventArgs e)
             {
-                bool isButton = t.Equals(ButtonClick.UseToolButton) ? e.IsUseToolButton : e.IsActionButton;
+                bool isButton = t.Equals(ButtonClick.UseToolButton) ? e.Button.IsUseToolButton() : e.Button.IsActionButton();
                 Point mousePosition = Game1.getMousePosition();
                 if (isButton && mousePosition == position)
                     handler.Invoke(position);
             };
 
-            InputEvents.ButtonPressed += d;
+            PyEvents.Events.Input.ButtonPressed += d;
             return d;
         }
 
-        /// <summary>Wraps the the method so it only executes if the player clicks on the screen area and adds it to InputEvents.ButtonPressed.</summary>
+        /// <summary>Wraps the the method so it only executes if the player clicks on the screen area and adds it to <see cref="IInputEvents.ButtonPressed"/>.</summary>
         /// <returns>Returns the wrapped method.</returns>
-        public static EventHandler<EventArgsInput> onClick(this ButtonClick t, Rectangle area, Action<Point> handler)
+        public static EventHandler<ButtonPressedEventArgs> onClick(this ButtonClick t, Rectangle area, Action<Point> handler)
         {
-            EventHandler<EventArgsInput> d = delegate (object sender, EventArgsInput e)
+            EventHandler<ButtonPressedEventArgs> d = delegate (object sender, ButtonPressedEventArgs e)
             {
-                bool isButton = t.Equals(ButtonClick.UseToolButton) ? e.IsUseToolButton : e.IsActionButton;
+                bool isButton = t.Equals(ButtonClick.UseToolButton) ? e.Button.IsUseToolButton() : e.Button.IsActionButton();
                 Point mousePosition = Game1.getMousePosition();
                 if (isButton && area.Contains(mousePosition))
                     handler.Invoke(mousePosition);
             };
 
-            InputEvents.ButtonPressed += d;
+            PyEvents.Events.Input.ButtonPressed += d;
             return d;
         }
 
-        /// <summary>Wraps the the method so it only executes if the player clicks on the specified tile and adds it to InputEvents.ButtonPressed.</summary>
+        /// <summary>Wraps the the method so it only executes if the player clicks on the specified tile and adds it to <see cref="IInputEvents.ButtonPressed"/>.</summary>
         /// <returns>Returns the wrapped method.</returns>
-        public static EventHandler<EventArgsInput> onClick(this ButtonClick t, Vector2 tile, GameLocation location, Action<Vector2> handler)
+        public static EventHandler<ButtonPressedEventArgs> onClick(this ButtonClick t, Vector2 tile, GameLocation location, Action<Vector2> handler)
         {
-            EventHandler<EventArgsInput> d = delegate (object sender, EventArgsInput e)
+            EventHandler<ButtonPressedEventArgs> d = delegate (object sender, ButtonPressedEventArgs e)
             {
-                bool isButton = t.Equals(ButtonClick.UseToolButton) ? e.IsUseToolButton : e.IsActionButton;
+                bool isButton = t.Equals(ButtonClick.UseToolButton) ? e.Button.IsUseToolButton() : e.Button.IsActionButton();
                 if (isButton && Game1.currentLocation == location && location.getTileAtMousePosition() == tile)
                     handler.Invoke(location.getTileAtMousePosition());
             };
 
-            InputEvents.ButtonPressed += d;
+            PyEvents.Events.Input.ButtonPressed += d;
             return d;
         }
 
 
-        /// <summary>Wraps the the method so it only executes if an object of the requested type is clicked on and adds it to InputEvents.ButtonPressed.</summary>
+        /// <summary>Wraps the the method so it only executes if an object of the requested type is clicked on and adds it to <see cref="IInputEvents.ButtonPressed"/>.</summary>
         /// <returns>Returns the wrapped method.</returns>
-        public static EventHandler<EventArgsInput> onObjectClick<T>(this ButtonClick t, EventHandler<T> handler) where T : SObject
+        public static EventHandler<ButtonPressedEventArgs> onObjectClick<T>(this ButtonClick t, EventHandler<T> handler) where T : SObject
         {
-            EventHandler<EventArgsInput> d = delegate (object sender, EventArgsInput e)
+            EventHandler<ButtonPressedEventArgs> d = delegate (object sender, ButtonPressedEventArgs e)
             {
-                bool isButton = t.Equals(ButtonClick.UseToolButton) ? e.IsUseToolButton : e.IsActionButton;
+                bool isButton = t.Equals(ButtonClick.UseToolButton) ? e.Button.IsUseToolButton() : e.Button.IsActionButton();
                 if (isButton && Game1.currentLocation is GameLocation location && location.getTileAtMousePosition().sObjectOnMap<T>() is T obj)
                     handler.Invoke(sender, obj);
             };
 
-            InputEvents.ButtonPressed += d;
+            PyEvents.Events.Input.ButtonPressed += d;
             return d;
         }
 
-        /// <summary>Wraps the the method so it only executes if an object of the requested type is clicked on and adds it to InputEvents.ButtonPressed.</summary>
+        /// <summary>Wraps the the method so it only executes if an object of the requested type is clicked on and adds it to <see cref="IInputEvents.ButtonPressed"/>.</summary>
         /// <returns>Returns the wrapped method.</returns>
-        public static EventHandler<EventArgsInput> onObjectClick<T>(this ButtonClick t, Action<T> handler) where T : SObject
+        public static EventHandler<ButtonPressedEventArgs> onObjectClick<T>(this ButtonClick t, Action<T> handler) where T : SObject
         {
-            EventHandler<EventArgsInput> d = delegate (object sender, EventArgsInput e)
+            EventHandler<ButtonPressedEventArgs> d = delegate (object sender, ButtonPressedEventArgs e)
             {
-                bool isButton = t.Equals(ButtonClick.UseToolButton) ? e.IsUseToolButton : e.IsActionButton;
+                bool isButton = t.Equals(ButtonClick.UseToolButton) ? e.Button.IsUseToolButton() : e.Button.IsActionButton();
                 if (isButton && Game1.currentLocation is GameLocation location && location.getTileAtMousePosition().sObjectOnMap<T>() is T obj)
                         handler.Invoke(obj);
             };
 
-            InputEvents.ButtonPressed += d;
+            PyEvents.Events.Input.ButtonPressed += d;
             return d;
         }
 
-        /// <summary>Wraps the the method so it only executes if an object of the requested type is clicked on and adds it to InputEvents.ButtonPressed.</summary>
+        /// <summary>Wraps the the method so it only executes if an object of the requested type is clicked on and adds it to <see cref="IInputEvents.ButtonPressed"/>.</summary>
         /// <returns>Returns the wrapped method.</returns>
-        public static EventHandler<EventArgsInput> onTerrainClick<T>(this ButtonClick t, Action<T> handler) where T : TerrainFeature
+        public static EventHandler<ButtonPressedEventArgs> onTerrainClick<T>(this ButtonClick t, Action<T> handler) where T : TerrainFeature
         {
-            EventHandler<EventArgsInput> d = delegate (object sender, EventArgsInput e)
+            EventHandler<ButtonPressedEventArgs> d = delegate (object sender, ButtonPressedEventArgs e)
             {
-                bool isButton = t.Equals(ButtonClick.UseToolButton) ? e.IsUseToolButton : e.IsActionButton;
+                bool isButton = t.Equals(ButtonClick.UseToolButton) ? e.Button.IsUseToolButton() : e.Button.IsActionButton();
                 if (isButton && Game1.currentLocation is GameLocation location && location.getTileAtMousePosition().terrainOnMap<T>() is T obj)
                     handler.Invoke(obj);
             };
 
-            InputEvents.ButtonPressed += d;
+            PyEvents.Events.Input.ButtonPressed += d;
             return d;
         }
 
-        /// <summary>Wraps the the method so it only executes if an object of the requested type is clicked on and adds it to InputEvents.ButtonPressed.</summary>
+        /// <summary>Wraps the the method so it only executes if an object of the requested type is clicked on and adds it to <see cref="IInputEvents.ButtonPressed"/>.</summary>
         /// <returns>Returns the wrapped method.</returns>
-        public static EventHandler<EventArgsInput> onTerrainClick<T>(this ButtonClick t, EventHandler<T> handler) where T : TerrainFeature
+        public static EventHandler<ButtonPressedEventArgs> onTerrainClick<T>(this ButtonClick t, EventHandler<T> handler) where T : TerrainFeature
         {
-            EventHandler<EventArgsInput> d = delegate (object sender, EventArgsInput e)
+            EventHandler<ButtonPressedEventArgs> d = delegate (object sender, ButtonPressedEventArgs e)
             {
-                bool isButton = t.Equals(ButtonClick.UseToolButton) ? e.IsUseToolButton : e.IsActionButton;
+                bool isButton = t.Equals(ButtonClick.UseToolButton) ? e.Button.IsUseToolButton() : e.Button.IsActionButton();
                 if (isButton && Game1.currentLocation is GameLocation location && location.getTileAtMousePosition().terrainOnMap<T>() is T obj)
                     handler.Invoke(sender, obj);
             };
 
-            InputEvents.ButtonPressed += d;
+            PyEvents.Events.Input.ButtonPressed += d;
             return d;
         }
 
-        /// <summary>Wraps the the method so it only executes if an object of the requested type is clicked on and adds it to InputEvents.ButtonPressed.</summary>
+        /// <summary>Wraps the the method so it only executes if an object of the requested type is clicked on and adds it to <see cref="IInputEvents.ButtonPressed"/>.</summary>
         /// <returns>Returns the wrapped method.</returns>
-        public static EventHandler<EventArgsInput> onFurnitureClick<T>(this ButtonClick t, EventHandler<T> handler) where T : Furniture
+        public static EventHandler<ButtonPressedEventArgs> onFurnitureClick<T>(this ButtonClick t, EventHandler<T> handler) where T : Furniture
         {
-            EventHandler<EventArgsInput> d = delegate (object sender, EventArgsInput e)
+            EventHandler<ButtonPressedEventArgs> d = delegate (object sender, ButtonPressedEventArgs e)
             {
-                bool isButton = t.Equals(ButtonClick.UseToolButton) ? e.IsUseToolButton : e.IsActionButton;
+                bool isButton = t.Equals(ButtonClick.UseToolButton) ? e.Button.IsUseToolButton() : e.Button.IsActionButton();
                 if (isButton && Game1.currentLocation is GameLocation location && location.getTileAtMousePosition().furnitureOnMap<T>() is T obj)
                     handler.Invoke(sender, obj);
             };
 
-            InputEvents.ButtonPressed += d;
+            PyEvents.Events.Input.ButtonPressed += d;
             return d;
         }
 
-        /// <summary>Wraps the the method so it only executes if an object of the requested type is clicked on and adds it to InputEvents.ButtonPressed.</summary>
+        /// <summary>Wraps the the method so it only executes if an object of the requested type is clicked on and adds it to <see cref="IInputEvents.ButtonPressed"/>.</summary>
         /// <returns>Returns the wrapped method.</returns>
-        public static EventHandler<EventArgsInput> onFurnitureClick<T>(this ButtonClick t, Action<T> handler) where T : Furniture
+        public static EventHandler<ButtonPressedEventArgs> onFurnitureClick<T>(this ButtonClick t, Action<T> handler) where T : Furniture
         {
-            EventHandler<EventArgsInput> d = delegate (object sender, EventArgsInput e)
+            EventHandler<ButtonPressedEventArgs> d = delegate (object sender, ButtonPressedEventArgs e)
             {
-                bool isButton = t.Equals(ButtonClick.UseToolButton) ? e.IsUseToolButton : e.IsActionButton;
+                bool isButton = t.Equals(ButtonClick.UseToolButton) ? e.Button.IsUseToolButton() : e.Button.IsActionButton();
                 if (isButton && Game1.currentLocation is GameLocation location && location.getTileAtMousePosition().furnitureOnMap<T>() is T obj)
                     handler.Invoke(obj);
             };
 
-            InputEvents.ButtonPressed += d;
+            PyEvents.Events.Input.ButtonPressed += d;
             return d;
         }
 
-        /// <summary>Wraps the the method so it only executes if this button is pressed and adds it to InputEvents.ButtonPressed.</summary>
+        /// <summary>Wraps the the method so it only executes if this button is pressed and adds it to <see cref="IInputEvents.ButtonPressed"/>.</summary>
         /// <returns>Returns the wrapped method.</returns>
-        public static EventHandler<EventArgsInput> onClick(this ButtonClick t, EventHandler<EventArgsInput> handler)
+        public static EventHandler<ButtonPressedEventArgs> onClick(this ButtonClick t, EventHandler<ButtonPressedEventArgs> handler)
         {
-            EventHandler<EventArgsInput> d = delegate (object sender, EventArgsInput e)
+            EventHandler<ButtonPressedEventArgs> d = delegate (object sender, ButtonPressedEventArgs e)
             {
-                bool isButton = t.Equals(ButtonClick.UseToolButton) ? e.IsUseToolButton : e.IsActionButton;
+                bool isButton = t.Equals(ButtonClick.UseToolButton) ? e.Button.IsUseToolButton() : e.Button.IsActionButton();
                 if (isButton)
                     handler.Invoke(sender, e);
             };
 
-            InputEvents.ButtonPressed += d;
+            PyEvents.Events.Input.ButtonPressed += d;
             return d;
         }
 
-        /// <summary>Wraps the the method so it only executes if this button is pressed and adds it to InputEvents.ButtonPressed.</summary>
+        /// <summary>Wraps the the method so it only executes if this button is pressed and adds it to <see cref="IInputEvents.ButtonPressed"/>.</summary>
         /// <returns>Returns the wrapped method.</returns>
-        public static EventHandler<EventArgsInput> onClick(this ButtonClick t, Action<EventArgsInput> handler)
+        public static EventHandler<ButtonPressedEventArgs> onClick(this ButtonClick t, Action<ButtonPressedEventArgs> handler)
         {
-            EventHandler<EventArgsInput> d = delegate (object sender, EventArgsInput e)
+            EventHandler<ButtonPressedEventArgs> d = delegate (object sender, ButtonPressedEventArgs e)
             {
-                bool isButton = t.Equals(ButtonClick.UseToolButton) ? e.IsUseToolButton : e.IsActionButton;
+                bool isButton = t.Equals(ButtonClick.UseToolButton) ? e.Button.IsUseToolButton() : e.Button.IsActionButton();
                 if (isButton)
                     handler.Invoke(e);
             };
 
-            InputEvents.ButtonPressed += d;
+            PyEvents.Events.Input.ButtonPressed += d;
             return d;
         }
 

--- a/PyTK/PyTKMod.cs
+++ b/PyTK/PyTKMod.cs
@@ -36,6 +36,7 @@ namespace PyTK
     public class PyTKMod : Mod
     {
         internal static IModHelper _helper;
+        internal static IModEvents _events => _helper.Events;
         internal static IMonitor _monitor;
         internal static bool _activeSpriteBatchFix = true;
         internal static string sdvContentFolder => PyUtils.getContentFolder();
@@ -263,7 +264,7 @@ namespace PyTK
             CustomObjectData.newObject("Platonymous.Rubici", Game1.objectSpriteSheet.clone().setSaturation(0), Color.Yellow, "Rubici", "Rubici Test", 16, "Rubici", "Minerals -2", 50, -300);
             new CustomObjectData("Platonymous.Rubico" + Color.Red.ToString(), "Rubico/250/-300/Minerals -2/Rubico/A precious stone that is sought after for its rich color and beautiful fluster.", Game1.objectSpriteSheet.clone().setSaturation(0), Color.Red, 16);
 
-            Keys.K.onPressed(() => Monitor.Log($"Played: {Game1.currentGameTime.TotalGameTime.Minutes} min"));
+            SButton.K.onPressed(() => Monitor.Log($"Played: {Game1.currentGameTime.TotalGameTime.Minutes} min"));
             ButtonClick.UseToolButton.onTerrainClick<Grass>(o => Monitor.Log($"Number of Weeds: {o.numberOfWeeds}", LogLevel.Info));
             new InventoryItem(new Chest(true), 100).addToNPCShop("Pierre");
             new ItemSelector<SObject>(p => p.name == "Chest").whenAddedToInventory(l => l.useAll(i => i.name = "Test"));

--- a/SwimSuit/SConfig.cs
+++ b/SwimSuit/SConfig.cs
@@ -1,16 +1,15 @@
-﻿
-using Microsoft.Xna.Framework.Input;
+﻿using StardewModdingAPI;
 
 namespace SwimSuit
 {
     class SConfig
     {
 
-        public Keys swimKey { get; set; }
+        public SButton swimKey { get; set; }
 
         public SConfig()
         {
-            swimKey = Keys.J;
+            swimKey = SButton.J;
         }
 
     }

--- a/SwimSuit/SwimSuitMod.cs
+++ b/SwimSuit/SwimSuitMod.cs
@@ -17,15 +17,13 @@ namespace SwimSuit
 
         public override void Entry(IModHelper helper)
         {
-            ControlEvents.KeyPressed += ControlEvents_KeyPressed;
+            helper.Events.Input.ButtonPressed += OnButtonPressed;
             config = Helper.ReadConfig<SConfig>(); 
         }
 
-        private void ControlEvents_KeyPressed(object sender, EventArgsKeyPressed e)
+        private void OnButtonPressed(object sender, ButtonPressedEventArgs e)
         {
-
-
-            if(e.KeyPressed == config.swimKey)
+            if(e.Button == config.swimKey)
             {
 
                 List<Vector2> tiles = getSurroundingTiles();

--- a/Ultiplayer/UltiplayerMod.cs
+++ b/Ultiplayer/UltiplayerMod.cs
@@ -11,7 +11,6 @@ using StardewValley;
 using StardewValley.Network;
 using StardewValley.Quests;
 using StardewModdingAPI.Events;
-using Microsoft.Xna.Framework.Input;
 using StardewValley.Menus;
 using StardewValley.Locations;
 using StardewValley.Buildings;
@@ -51,7 +50,7 @@ namespace Ultiplayer
             #region events
             TimeEvents.AfterDayStarted += (s, e) => SaveFarmhand();
             SaveEvents.AfterLoad += (s, e) => LoadFarmhands();
-            ControlEvents.KeyPressed += (s, e) => keyPressed(e.KeyPressed);
+            helper.Events.Input.ButtonPressed += (s, e) => OnButtonPressed(e.Button);
             GraphicsEvents.OnPostRenderGuiEvent += GraphicsEvents_OnPostRenderGuiEvent;
             #endregion
         }
@@ -71,7 +70,7 @@ namespace Ultiplayer
 
         #region inputHandling
 
-        internal void keyPressed(Keys key)
+        internal void OnButtonPressed(SButton key)
         {
             if (Game1.IsClient)
             {
@@ -90,11 +89,11 @@ namespace Ultiplayer
                     Game1.getLocationFromName("FarmHouse").map.inject(@"Maps/FarmHouse_" + Game1.player.UniqueMultiplayerID);
                     Game1.locations.Add(new FarmHouse(@"Maps/FarmHouse_" + Game1.player.UniqueMultiplayerID, "FarmHouse_" + Game1.player.UniqueMultiplayerID));
                 }
-                if (key == Keys.J)
+                if (key == SButton.J)
                     Game1.warpFarmer("FarmHouse_" + Game1.player.UniqueMultiplayerID, 100, 50, 1);
             }
 
-            if (Game1.activeClickableMenu is TitleMenu t && key == Keys.U)
+            if (Game1.activeClickableMenu is TitleMenu t && key == SButton.U)
             {
                 ultiplayer = !ultiplayer;
                 mon.Log(ultiplayer ? "Ultiplayer activated" : "Ultiplayer deactivated", LogLevel.Info);

--- a/Visualize/Config.cs
+++ b/Visualize/Config.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Xna.Framework.Input;
+﻿using StardewModdingAPI;
 
 namespace Visualize
 {
@@ -6,11 +6,11 @@ namespace Visualize
     {
         public string activeProfile { get; set; } = "Platonymous.Original";
         public float saturation { get; set; } = 100;
-        public Keys next { get; set; } = Keys.PageDown;
-        public Keys previous { get; set; } = Keys.PageUp;
-        public Keys satHigher { get; set; } = Keys.NumPad9;
-        public Keys satLower { get; set; } = Keys.NumPad6;
-        public Keys reset { get; set; } = Keys.NumPad0;
+        public SButton next { get; set; } = SButton.PageDown;
+        public SButton previous { get; set; } = SButton.PageUp;
+        public SButton satHigher { get; set; } = SButton.NumPad9;
+        public SButton satLower { get; set; } = SButton.NumPad6;
+        public SButton reset { get; set; } = SButton.NumPad0;
         public int passes { get; set; } = 10;
 
     }

--- a/Visualize/VisualizeMod.cs
+++ b/Visualize/VisualizeMod.cs
@@ -35,7 +35,7 @@ namespace Visualize
             _helper = Helper;
             loadProfiles();
             setActiveProfile(new Profile());
-            ControlEvents.KeyPressed += ControlEvents_KeyPressed;
+            this.Helper.Events.Input.ButtonPressed += OnButtonPressed;
             GameEvents.HalfSecondTick += GameEvents_HalfSecondTick;
             MenuEvents.MenuChanged += MenuEvents_MenuChanged;
             TimeEvents.AfterDayStarted += TimeEvents_AfterDayStarted;
@@ -67,23 +67,23 @@ namespace Visualize
             return true;
         }
 
-        private void ControlEvents_KeyPressed(object sender, EventArgsKeyPressed e)
+        private void OnButtonPressed(object sender, ButtonPressedEventArgs e)
         {
-            if (e.KeyPressed == _config.next)
+            if (e.Button == _config.next)
                 switchProfile(1);
 
-            if (e.KeyPressed == _config.previous)
+            if (e.Button == _config.previous)
                 switchProfile(-1);
 
-            if (e.KeyPressed == _config.reset)
+            if (e.Button == _config.reset)
                 reset();
 
-            if (e.KeyPressed == _config.satHigher || e.KeyPressed == _config.satLower)
+            if (e.Button == _config.satHigher || e.Button == _config.satLower)
             {
-                if (e.KeyPressed == _config.satHigher)
+                if (e.Button == _config.satHigher)
                     _config.saturation = MathHelper.Min(200, _config.saturation + 10);
 
-                if (e.KeyPressed == _config.satLower)
+                if (e.Button == _config.satLower)
                     _config.saturation = MathHelper.Max(0, _config.saturation - 10);
 
                 emptyCache();


### PR DESCRIPTION
This pull request updates input events for compatibility with the upcoming SMAPI 3.0. This notably replaces `Keys` with `SButton` (a unified constant for controller/keyboard/mouse buttons), and provides new events like `CursorMoved` to simplify some cases.

The change is seamless in most cases, except that it introduces a breaking change to the `PyEvents`. Mods which use those will need to replace code like `Keys.U.onPressed(...)` with `SButton.U.onPressed(...)`. I searched [the mod source dump](https://github.com/Pathoschild/smapi-mod-dump) for usages, and it seems only your mods are affected (at least among open-source mods). If needed I can can add backwards-compatible overloads so existing usages will work fine, though.