### PR TITLE
Typo fix - CAUTION

### DIFF
--- a/HarpOfYobaRedux/Instrument.cs
+++ b/HarpOfYobaRedux/Instrument.cs
@@ -228,9 +228,9 @@ namespace HarpOfYobaRedux
             SheetMusic sheet = (SheetMusic)attachments[0];
 
             PyUtils.setDelayedAction(1000, animation.animate);
-            PyUtils.setDelayedAction(sheet.lenght / 2, doMagic);
-            PyUtils.setDelayedAction(sheet.lenght, resetMusic);
-            PyUtils.setDelayedAction(sheet.lenght + 1000, stop);
+            PyUtils.setDelayedAction(sheet.length / 2, doMagic);
+            PyUtils.setDelayedAction(sheet.length, resetMusic);
+            PyUtils.setDelayedAction(sheet.length + 1000, stop);
 
             animation.preAnimation();
             sheet.play();


### PR DESCRIPTION
I noticed a typo in `play()`. However, take caution - merging this patch may have unintended consequences, as deployed version 2.6.3 seems to be functional in spite of this presumable null reference. Merging this change may cause unexpected behavior.