### PR TITLE
Fix deprecated API usage

### DIFF
--- a/CustomFarmingRedux/CustomFarmingReduxMod.cs
+++ b/CustomFarmingRedux/CustomFarmingReduxMod.cs
@@ -203,7 +203,7 @@ namespace CustomFarmingRedux
         {
             List<CustomFarmingPack> packs = new List<CustomFarmingPack>();
 
-            foreach (StardewModdingAPI.IContentPack pack in Helper.GetContentPacks())
+            foreach (StardewModdingAPI.IContentPack pack in Helper.ContentPacks.GetOwned())
             {
                 List<CustomFarmingPack> cpPacks = loadCP(pack);
                 packs.AddRange(cpPacks);

--- a/CustomFarmingRedux/manifest.json
+++ b/CustomFarmingRedux/manifest.json
@@ -6,7 +6,7 @@
   "UniqueID": "Platonymous.CustomFarming",
   "EntryDll": "CustomFarmingRedux.dll",
   "UpdateKeys": [ "Nexus:991" ],
-  "MinimumApiVersion": "2.9.0",
+  "MinimumApiVersion": "2.9.3",
   "Dependencies": [
     {
       "UniqueID": "Platonymous.Toolkit",

--- a/CustomFurniture/CustomFurnitureMod.cs
+++ b/CustomFurniture/CustomFurnitureMod.cs
@@ -120,7 +120,7 @@ namespace CustomFurniture
             int countPacks = 0;
             int countObjects = 0;
 
-            var contentPacks = Helper.GetContentPacks();
+            var contentPacks = Helper.ContentPacks.GetOwned();
 
             foreach (IContentPack cpack in contentPacks)
             {

--- a/CustomFurniture/manifest.json
+++ b/CustomFurniture/manifest.json
@@ -5,7 +5,7 @@
   "Description": "Helper Mod for Custom Furniture creation.",
   "UniqueID": "Platonymous.CustomFurniture",
   "EntryDll": "CustomFurniture.dll",
-  "MinimumApiVersion": "2.9.0",
+  "MinimumApiVersion": "2.9.3",
   "UpdateKeys": [ "Nexus:1254" ],
   "Dependencies": [
     {

--- a/CustomMusic/CustomMusicMod.cs
+++ b/CustomMusic/CustomMusicMod.cs
@@ -101,7 +101,7 @@ namespace CustomMusic
 
         private void loadContentPacks()
         {
-            foreach (IContentPack pack in Helper.GetContentPacks())
+            foreach (IContentPack pack in Helper.ContentPacks.GetOwned())
             {
                 MusicContent content = pack.ReadJsonFile<MusicContent>("content.json");
 

--- a/CustomMusic/manifest.json
+++ b/CustomMusic/manifest.json
@@ -5,6 +5,6 @@
   "Description": "Changes the games music",
   "UniqueID": "Platonymous.CustomMusic",
   "EntryDll": "CustomMusic.dll",
-  "MinimumApiVersion": "2.9.0",
+  "MinimumApiVersion": "2.9.3",
   "UpdateKeys": [ "Nexus:3043" ]
 }

--- a/CustomShirts/CustomShirtsMod.cs
+++ b/CustomShirts/CustomShirtsMod.cs
@@ -158,7 +158,7 @@ namespace CustomShirts
 
         private void loadContentPacks()
         {
-            foreach (StardewModdingAPI.IContentPack pack in Helper.GetContentPacks())
+            foreach (StardewModdingAPI.IContentPack pack in Helper.ContentPacks.GetOwned())
             {
                 ShirtPack shirtPack = pack.ReadJsonFile<ShirtPack>("content.json");
 

--- a/CustomShirts/manifest.json
+++ b/CustomShirts/manifest.json
@@ -5,7 +5,7 @@
   "Description": "Add custom shirts to the game",
   "UniqueID": "Platonymous.CustomShirts",
   "EntryDll": "CustomShirts.dll",
-  "MinimumApiVersion": "2.9.0",
+  "MinimumApiVersion": "2.9.3",
   "UpdateKeys": [ "Nexus:2416" ],
   "Dependencies": [
     {

--- a/CustomWallsAndFloors/CustomWallsAndFloorsMod.cs
+++ b/CustomWallsAndFloors/CustomWallsAndFloorsMod.cs
@@ -130,7 +130,7 @@ namespace CustomWallsAndFloors
 
         private void loadContentPacks()
         {
-            foreach (StardewModdingAPI.IContentPack pack in Helper.GetContentPacks())
+            foreach (StardewModdingAPI.IContentPack pack in Helper.ContentPacks.GetOwned())
             {
                 Animations animations = null;
 

--- a/CustomWallsAndFloors/manifest.json
+++ b/CustomWallsAndFloors/manifest.json
@@ -5,7 +5,7 @@
   "Description": "Add custom Walls and Floors to SDV",
   "UniqueID": "Platonymous.CustomWallsAndFloors",
   "EntryDll": "CustomWallsAndFloors.dll",
-  "MinimumApiVersion": "2.9.0",
+  "MinimumApiVersion": "2.9.3",
   "UpdateKeys": [ "Nexus:3010" ],
   "Dependencies": [
     {

--- a/Portraiture/TextureLoader.cs
+++ b/Portraiture/TextureLoader.cs
@@ -92,7 +92,7 @@ namespace Portraiture
                 }
             }
 
-            var contentPacks = PortraitureMod.helper.GetContentPacks();
+            var contentPacks = PortraitureMod.helper.ContentPacks.GetOwned();
 
             foreach (StardewModdingAPI.IContentPack pack in contentPacks)
             {

--- a/Portraiture/manifest.json
+++ b/Portraiture/manifest.json
@@ -5,7 +5,7 @@
   "Description": "Helper Mod for Portraits.",
   "UniqueID": "Platonymous.Portraiture",
   "EntryDll": "Portraiture.dll",
-  "MinimumApiVersion": "2.9.0",
+  "MinimumApiVersion": "2.9.3",
   "UpdateKeys": [ "Nexus:999" ],
   "Dependencies": [
     {

--- a/TMXLoader/TMXLoaderMod.cs
+++ b/TMXLoader/TMXLoaderMod.cs
@@ -99,7 +99,7 @@ namespace TMXLoader
 
         private void loadContentPacks()
         {
-            foreach (StardewModdingAPI.IContentPack pack in Helper.GetContentPacks())
+            foreach (StardewModdingAPI.IContentPack pack in Helper.ContentPacks.GetOwned())
             {
                 TMXContentPack tmxPack = pack.ReadJsonFile<TMXContentPack>("content.json");
 

--- a/TMXLoader/manifest.json
+++ b/TMXLoader/manifest.json
@@ -6,7 +6,7 @@
   "UniqueID": "Platonymous.TMXLoader",
   "EntryDll": "TMXLoader.dll",
   "UpdateKeys": [ "Nexus:1820" ],
-  "MinimumApiVersion": "2.9.0",
+  "MinimumApiVersion": "2.9.3",
   "Dependencies": [
     {
       "UniqueID": "Platonymous.Toolkit",


### PR DESCRIPTION
This pull request replaces `helper.GetContentPacks()` with the newer `helper.ContentPacks.GetOwned()`, for compatibility with the upcoming SMAPI 3.0. (The new API is available since SMAPI 2.9.2.)