### PR TITLE
Reference name to build id

### DIFF
--- a/CustomFarmingRedux/RecipeBlueprint.cs
+++ b/CustomFarmingRedux/RecipeBlueprint.cs
@@ -24,7 +24,7 @@ namespace CustomFarmingRedux
         public int _index = -1;
         public int[] exclude;
         public int[] include;
-        public string id => _name + "." + _index + "." + quality + "." + stack;
+        public string id => name + "." + _index + "." + quality + "." + stack;
         public string price = "original";
         private int dropInQuality = -1;
         public string name


### PR DESCRIPTION
Reference name instead of _name when building id, to force initialization of the name.  This allows automated machines to correctly identify their recipe after restarting game.