### PR TITLE
Update for SMAPI 3.0 and Automate 1.12

### DIFF
--- a/Arcade2048/Arcade2048Mod.cs
+++ b/Arcade2048/Arcade2048Mod.cs
@@ -4,7 +4,6 @@ using PyTK.CustomElementHandler;
 using PyTK.Extensions;
 using PyTK.Types;
 using StardewModdingAPI;
-using StardewModdingAPI.Events;
 
 namespace Arcade2048
 {
@@ -16,7 +15,10 @@ namespace Arcade2048
         public override void Entry(IModHelper helper)
         {
             monitor = Monitor;
-            sdata = new CustomObjectData("2048", "2048/0/-300/Crafting -9/Play '2048 by Platonymous' at home!/true/true/0/2048", helper.Content.Load<Texture2D>(@"Assets/arcade.png"), Color.White, bigCraftable: true, type: typeof(Machine2048));
+            helper.Events.GameLoop.GameLaunched += (o, e) =>
+            {
+                sdata = new CustomObjectData("2048", "2048/0/-300/Crafting -9/Play '2048 by Platonymous' at home!/true/true/0/2048", helper.Content.Load<Texture2D>(@"Assets/arcade.png"), Color.White, bigCraftable: true, type: typeof(Machine2048));
+            };
             helper.Events.GameLoop.SaveLoaded += (o, e) => addToCatalogue();
         }
 

--- a/CFAutomate/CFAutomate.csproj
+++ b/CFAutomate/CFAutomate.csproj
@@ -36,7 +36,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Automate">
-      <HintPath>C:\Program Files (x86)\GOG Galaxy\Games\Stardew Valley\Mods\Automate\Automate.dll</HintPath>
+      <HintPath>$(GamePath)\Mods\Automate\Automate.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System" />

--- a/CFAutomate/Framework/AutomatedMachine.cs
+++ b/CFAutomate/Framework/AutomatedMachine.cs
@@ -28,6 +28,10 @@ namespace CFAutomate.Framework
         /// <summary>The tile area covered by the machine.</summary>
         public Rectangle TileArea { get; }
 
+        /// <summary>A unique ID for the machine type.</summary>
+        /// <remarks>This value should be identical for two machines if they have the exact same behavior and input logic. For example, if one machine in a group can't process input due to missing items, Automate will skip any other empty machines of that type in the same group since it assumes they need the same inputs.</remarks>
+        public string MachineTypeID => this.Machine.id;
+
 
         /*********
         ** Public methods

--- a/CustomFarmingRedux/CustomFarmingReduxMod.cs
+++ b/CustomFarmingRedux/CustomFarmingReduxMod.cs
@@ -36,13 +36,22 @@ namespace CustomFarmingRedux
             _helper = Helper;
             _monitor = Monitor;
             _config = Helper.ReadConfig<Config>();
-
             hasKisekae = helper.ModRegistry.IsLoaded("Kabigon.kisekae");
 
+            helper.Events.GameLoop.GameLaunched += OnGameLaunched;
+            helper.Events.Display.MenuChanged += OnMenuChanged;
+            helper.Events.GameLoop.SaveLoaded += OnSaveLoaded;
+
+            harmonyFix();
+            helper.ConsoleCommands.Add("replace_custom_farming", "Triggers Custom Farming Replacement", replaceCustomFarming);
+        }
+
+        private void OnGameLaunched(object sender, GameLaunchedEventArgs e)
+        {
             if (hasKisekae)
             {
-                var registry = helper.ModRegistry.GetType().GetField("Registry", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(helper.ModRegistry);
-                System.Collections.IList list = (System.Collections.IList) registry.GetType().GetField("Mods", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(registry);
+                var registry = Helper.ModRegistry.GetType().GetField("Registry", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(Helper.ModRegistry);
+                System.Collections.IList list = (System.Collections.IList)registry.GetType().GetField("Mods", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(registry);
                 foreach (var m in list)
                 {
                     IManifest mmanifest = (IManifest)m.GetType().GetProperty("Manifest").GetValue(m);
@@ -55,32 +64,26 @@ namespace CustomFarmingRedux
             }
 
             loadPacks();
-            helper.Events.Display.MenuChanged += OnMenuChanged;
-            helper.Events.GameLoop.SaveLoaded += (s, e) =>
-            {
-                foreach (var c in craftingrecipes)
-                    if (Game1.player.craftingRecipes.ContainsKey(c.Key))
-                        Game1.player.craftingRecipes[c.Key] = c.Value;
-                    else
-                        Game1.player.craftingRecipes.Add(c.Key, c.Value);
-
-                CustomObject.betterArtisanGoods = System.Type.GetType("BetterArtisanGoodIcons.ArtisanGoodsManager, BetterArtisanGoodIcons");
-                CustomObject.hasBetterArtisanGoods = CustomObject.betterArtisanGoods != null;
-            };
-
-            harmonyFix();
-            helper.ConsoleCommands.Add("replace_custom_farming", "Triggers Custom Farming Replacement", replaceCustomFarming);
 
             if (_config.water)
             {
-                helper.Events.GameLoop.GameLaunched += (s, e) =>
-                {
-                    new CustomObjectData("Platonymous.Water", "Water/1/2/Cooking -7/Water/Plain drinking water./drink/0 0 0 0 0 0 0 0 0 0 0/0", Game1.objectSpriteSheet.getTile(247).setSaturation(0), Color.Aqua, type: typeof(WaterItem));
-                    ButtonClick.ActionButton.onClick((pos) => clickedOnWateringCan(pos), (p) => convertWater());
-                };
+                new CustomObjectData("Platonymous.Water", "Water/1/2/Cooking -7/Water/Plain drinking water./drink/0 0 0 0 0 0 0 0 0 0 0/0", Game1.objectSpriteSheet.getTile(247).setSaturation(0), Color.Aqua, type: typeof(WaterItem));
+                ButtonClick.ActionButton.onClick((pos) => clickedOnWateringCan(pos), (p) => convertWater());
             }
 
-            PyLua.registerType(typeof(CustomMachine),registerAssembly:true);
+            PyLua.registerType(typeof(CustomMachine), registerAssembly: true);
+        }
+
+        private void OnSaveLoaded(object sender, SaveLoadedEventArgs e)
+        {
+            foreach (var c in craftingrecipes)
+                if (Game1.player.craftingRecipes.ContainsKey(c.Key))
+                    Game1.player.craftingRecipes[c.Key] = c.Value;
+                else
+                    Game1.player.craftingRecipes.Add(c.Key, c.Value);
+
+            CustomObject.betterArtisanGoods = System.Type.GetType("BetterArtisanGoodIcons.ArtisanGoodsManager, BetterArtisanGoodIcons");
+            CustomObject.hasBetterArtisanGoods = CustomObject.betterArtisanGoods != null;
         }
 
         private bool clickedOnWateringCan(Point pos)

--- a/CustomFarmingRedux/CustomFarmingReduxMod.cs
+++ b/CustomFarmingRedux/CustomFarmingReduxMod.cs
@@ -66,15 +66,18 @@ namespace CustomFarmingRedux
 
                 CustomObject.betterArtisanGoods = System.Type.GetType("BetterArtisanGoodIcons.ArtisanGoodsManager, BetterArtisanGoodIcons");
                 CustomObject.hasBetterArtisanGoods = CustomObject.betterArtisanGoods != null;
-    };
+            };
 
             harmonyFix();
             helper.ConsoleCommands.Add("replace_custom_farming", "Triggers Custom Farming Replacement", replaceCustomFarming);
 
-            if(_config.water)
+            if (_config.water)
             {
-                new CustomObjectData("Platonymous.Water", "Water/1/2/Cooking -7/Water/Plain drinking water./drink/0 0 0 0 0 0 0 0 0 0 0/0", Game1.objectSpriteSheet.getTile(247).setSaturation(0), Color.Aqua, type: typeof(WaterItem));
-                ButtonClick.ActionButton.onClick((pos) => clickedOnWateringCan(pos), (p) => convertWater());
+                helper.Events.GameLoop.GameLaunched += (s, e) =>
+                {
+                    new CustomObjectData("Platonymous.Water", "Water/1/2/Cooking -7/Water/Plain drinking water./drink/0 0 0 0 0 0 0 0 0 0 0/0", Game1.objectSpriteSheet.getTile(247).setSaturation(0), Color.Aqua, type: typeof(WaterItem));
+                    ButtonClick.ActionButton.onClick((pos) => clickedOnWateringCan(pos), (p) => convertWater());
+                };
             }
 
             PyLua.registerType(typeof(CustomMachine),registerAssembly:true);

--- a/CustomFarmingRedux/CustomMachine.cs
+++ b/CustomFarmingRedux/CustomMachine.cs
@@ -34,7 +34,7 @@ namespace CustomFarmingRedux
         private bool active = true;
         private bool wasBuild = false;
         public virtual bool isWorking { get => active && !readyForHarvest && ((completionTime != null && activeRecipe != null) || blueprint.production == null); }
-        private string id;
+        public string id { get; private set; }
         public string conditions = null;
         public virtual STime completionTime { get; set; }
         private int tileindex;

--- a/HarpOfYobaRedux/HarpOfYobaReduxMod.cs
+++ b/HarpOfYobaRedux/HarpOfYobaReduxMod.cs
@@ -19,7 +19,7 @@ namespace HarpOfYobaRedux
             new ConsoleCommand("hoy_cheat", "Get all sheets without doing anything.", (c, p) => cheat(p)).register();
             helper.Events.Display.MenuChanged += OnMenuChanged;
             helper.Events.GameLoop.Saving += OnSaving;
-            DataLoader.load(Helper, Helper.ModRegistry.IsLoaded("Platonymous.CustomMusic"));
+            helper.Events.GameLoop.GameLaunched += OnGameLaunched;
         }
 
         private void cheat(string[] p)
@@ -46,6 +46,11 @@ namespace HarpOfYobaRedux
             }
             if(items.Count > 0)
                 Game1.activeClickableMenu = new ItemGrabMenu(items);
+        }
+
+        private void OnGameLaunched(object sender, GameLaunchedEventArgs e)
+        {
+            DataLoader.load(Helper, Helper.ModRegistry.IsLoaded("Platonymous.CustomMusic"));
         }
 
         private void OnSaving(object sender, SavingEventArgs e)

--- a/JoJaBan/JoJaBanMod.cs
+++ b/JoJaBan/JoJaBanMod.cs
@@ -38,11 +38,14 @@ namespace JoJaBan
             TileAction startAction = new TileAction("JoJaBan.Start", startGame);
             startAction.register();
 
-            arcadeTexture = helper.Content.Load<Texture2D>(@"Assets/arcade.png");
-            arcadeData = new CustomObjectData("JoJaBan", "JoJaBan/0/-300/Crafting -9/Play 'JoJaBan by Platonymous' at home!/true/true/0/JoJaBan", arcadeTexture, Color.White, bigCraftable: true, type: typeof(JoJaBanMachine));
-            Texture2D townInterior = Helper.Content.Load<Texture2D>(@"Maps/townInterior", ContentSource.GameContent);
-            boxTexture = townInterior.getArea(new Rectangle(304, 1024, 16, 32));
-            boxData = new CustomObjectData("JoJa Box", "JoJa Box/0/-300/Crafting -9/JoJa Box/true/true/0/JoJa Box", boxTexture, Color.White, bigCraftable: true, type:typeof(JoJaBox));
+            helper.Events.GameLoop.GameLaunched += (o, e) =>
+            {
+                arcadeTexture = helper.Content.Load<Texture2D>(@"Assets/arcade.png");
+                arcadeData = new CustomObjectData("JoJaBan", "JoJaBan/0/-300/Crafting -9/Play 'JoJaBan by Platonymous' at home!/true/true/0/JoJaBan", arcadeTexture, Color.White, bigCraftable: true, type: typeof(JoJaBanMachine));
+                Texture2D townInterior = Helper.Content.Load<Texture2D>(@"Maps/townInterior", ContentSource.GameContent);
+                boxTexture = townInterior.getArea(new Rectangle(304, 1024, 16, 32));
+                boxData = new CustomObjectData("JoJa Box", "JoJa Box/0/-300/Crafting -9/JoJa Box/true/true/0/JoJa Box", boxTexture, Color.White, bigCraftable: true, type: typeof(JoJaBox));
+            };
             helper.Events.Input.ButtonPressed += OnButtonPressed;
             helper.Events.GameLoop.SaveLoaded += (o, e) => addToCatalogue();
         }

--- a/Notes/NotesMod.cs
+++ b/Notes/NotesMod.cs
@@ -22,8 +22,8 @@ namespace Notes
         {
             Logger = Monitor;
             NoteInfo = i18n.Get("notes.note.info");
-            initNotes();
 
+            helper.Events.GameLoop.GameLaunched += (s, e) => initNotes();
             helper.Events.Input.CursorMoved += (s,e) => checkForSigns(e.NewPosition);
             helper.Events.Display.Rendered += OnRendered;
         }

--- a/PyTK/CustomElementHandler/CustomObjectData.cs
+++ b/PyTK/CustomElementHandler/CustomObjectData.cs
@@ -116,6 +116,9 @@ namespace PyTK.CustomElementHandler
 
         public CustomObjectData(string id, string data, Texture2D texture, Color color, int tileIndex = 0, bool bigCraftable = false, Type type = null, CraftingData craftingData = null)
         {
+            if (Game1.objectInformation == null)
+                throw new InvalidOperationException("Can't create a custom object before the game is initialised.");
+
             this.id = id;
             this.data = data;
             this.texture = texture;

--- a/PyTK/Extensions/PyTextures.cs
+++ b/PyTK/Extensions/PyTextures.cs
@@ -85,6 +85,9 @@ namespace PyTK.Extensions
 
         public static Texture2D getTile(this Texture2D t, int index, int tileWidth = 16, int tileHeight = 16)
         {
+            if (t == null)
+                return null;
+
             Rectangle sourceRectangle = Game1.getSourceRectForStandardTileSheet(t, index, tileWidth, tileHeight);
             return t.getArea(sourceRectangle);
         }

--- a/SeedBag/SeedBagMod.cs
+++ b/SeedBag/SeedBagMod.cs
@@ -18,6 +18,12 @@ namespace SeedBag
         {
             _monitor = Monitor;
             _helper = helper;
+
+            helper.Events.GameLoop.GameLaunched += OnGameLaunched;
+        }
+
+        private void OnGameLaunched(object sender, GameLaunchedEventArgs e)
+        {
             SeedBagTool seedbag = new SeedBagTool();
             addtoshop = new InventoryItem(seedbag, 30000, 1).addToNPCShop("Pierre");
             CustomObjectData.newObject("Platonymous.SeedBag.Tool", SeedBagTool.texture, Color.White, "Seed Bag", "Empty", 0, customType: typeof(SeedBagTool));

--- a/Snake/SnakeMod.cs
+++ b/Snake/SnakeMod.cs
@@ -24,7 +24,10 @@ namespace Snake
         {
             monitor = Monitor;
             SnakeMod.helper = helper;
-            sdata = new CustomObjectData("Snake", "Snake/0/-300/Crafting -9/Play 'Snake by Platonymous' at home!/true/true/0/Snake", helper.Content.Load<Texture2D>(@"Assets/arcade.png"), Color.White, bigCraftable: true, type: typeof(SnakeMachine));
+            helper.Events.GameLoop.GameLaunched += (o, e) =>
+            {
+                sdata = new CustomObjectData("Snake", "Snake/0/-300/Crafting -9/Play 'Snake by Platonymous' at home!/true/true/0/Snake", helper.Content.Load<Texture2D>(@"Assets/arcade.png"), Color.White, bigCraftable: true, type: typeof(SnakeMachine));
+            };
             helper.Events.GameLoop.SaveLoaded += (o, e) =>
             {
                 if (Game1.IsMasterGame)

--- a/SplitMoney/SplitMoneyMod.cs
+++ b/SplitMoney/SplitMoneyMod.cs
@@ -46,6 +46,14 @@ namespace SplitMoney
             }, 30);
             moneyPoolReceiver.start();
 
+            #region moneyItem
+            helper.Events.GameLoop.GameLaunched += (s, e) =>
+            {
+                new CustomObjectData("Platonymous.G", "G/1/-300/Basic/G/The common currency of Pelican Town.", Game1.mouseCursors.getArea(new Rectangle(280, 410, 16, 16)), Color.White, type: typeof(GoldItem));
+                ButtonClick.ActionButton.onClick((pos) => new List<IClickableMenu>(Game1.onScreenMenus).Exists(m => m is DayTimeMoneyBox && m.isWithinBounds(pos.X, pos.Y - 180) && m.isWithinBounds(pos.X, pos.Y) && m.isWithinBounds(pos.X, pos.Y + 50)), (p) => convertMoney());
+            };
+            #endregion
+
             helper.Events.GameLoop.ReturnedToTitle += (s, e) => { myMoney = -1; lockMoney = true; };
             helper.Events.GameLoop.Saving += (s, e) =>
             {
@@ -79,11 +87,6 @@ namespace SplitMoney
                 moneyPool = new Dictionary<string, int>();
                 lockMoney = false;
             };
-
-            #region moneyItem
-            new CustomObjectData("Platonymous.G", "G/1/-300/Basic/G/The common currency of Pelican Town.", Game1.mouseCursors.getArea(new Rectangle(280, 410, 16, 16)), Color.White, type: typeof(GoldItem));
-            ButtonClick.ActionButton.onClick((pos) => new List<IClickableMenu>(Game1.onScreenMenus).Exists(m => m is DayTimeMoneyBox && m.isWithinBounds(pos.X, pos.Y - 180) && m.isWithinBounds(pos.X, pos.Y) && m.isWithinBounds(pos.X, pos.Y + 50)), (p) => convertMoney());
-            #endregion
 
             #region harmony
             HarmonyInstance instance = HarmonyInstance.Create("Platonymous.SplitMoney");


### PR DESCRIPTION
* SMAPI 3.0 now loads mods much earlier in the game cycle, so it's easier to change some parts of the game (like core spritesheets). That means mods are loaded before some game init logic, notably loading core data like `Game1.objectInformation`.

  This PR fixes affected mods by performing some init logic in the `GameLaunched` event instead. Based on a search of [my mod dump repo](https://github.com/Pathoschild/smapi-mod-dump), the `CustomObjectData` change doesn't affect any known open-source mods outside this repo.

* This PR also updates CFAutomate for compatibility with Automate 1.12, which adds a `MachineTypeID` field to machines to enable optimisations.

(Followup to #37.)