### PR TITLE
Fixes a NullReferenceException when the compared location is null

### DIFF
--- a/PyTK/Overrides/OvLocations.cs
+++ b/PyTK/Overrides/OvLocations.cs
@@ -34,7 +34,7 @@ namespace PyTK.Overrides
 
             internal static bool Prefix(GameLocation __instance, GameLocation other, ref bool __result)
             {
-                __result = object.Equals((object)__instance.Name, (object)other.Name) && object.Equals((object)__instance.uniqueName.Value, (object)other.uniqueName.Value ) && object.Equals((object)__instance.isStructure.Value, (object)other.isStructure.Value);
+                __result = object.Equals((object)__instance.Name, (object)other?.Name) && object.Equals((object)__instance.uniqueName.Value, (object)other?.uniqueName.Value ) && object.Equals((object)__instance.isStructure.Value, (object)other?.isStructure.Value);
                 return false;
             }
         }


### PR DESCRIPTION
This change adjusts the Equals check to more closely implement it as per [Microsoft's documentation specifies](https://docs.microsoft.com/en-us/dotnet/api/system.object.equals#notes-for-inheritors) (specifically "Implementations of Equals must not throw exceptions; they should always return a value."), as well as fixes a bug that is noticed in the [Skull Cavern Elevator](https://www.nexusmods.com/stardewvalley/mods/963/) mod when PyTK is installed (as mentioned in the bug report for PyTK on NexusMods).