### PR TITLE
[CFR] Update auto-coloring

### DIFF
--- a/CustomFarmingRedux/CustomObject.cs
+++ b/CustomFarmingRedux/CustomObject.cs
@@ -158,11 +158,11 @@ namespace CustomFarmingRedux
                     data2[(y - y2) * w + (x - x2)] = data[y * texture.Width + x];
 
             List<Color> colors = data2.ToList();
-            colors.RemoveAll(p => p == Color.White || p == Color.Black);
+            colors.RemoveAll(p => p == Color.White || p == Color.Black || p.A < 128);
 
-            int R = (int)colors.toList(c => (int)c.R).Average();
-            int G = (int)colors.toList(c => (int)c.G).Average(); ;
-            int B = (int)colors.toList(c => (int)c.B).Average(); ;
+            int R = (int)Math.Sqrt(colors.toList(c => c.R * c.R).Average());
+            int G = (int)Math.Sqrt(colors.toList(c => c.G * c.G).Average());
+            int B = (int)Math.Sqrt(colors.toList(c => c.B * c.B).Average());
 
             int nR = R;
             int nG = G;


### PR DESCRIPTION
This updates the auto-coloring in Custom Farming Redux to ignore pixels alpha level less than 50%. This is combined by averaging colors [the correct way](https://sighack.com/post/averaging-rgb-colors-the-right-way). This makes the colors a lot more accurate to the source image.

Before:
![before](https://user-images.githubusercontent.com/1270500/66280670-be268280-e885-11e9-8045-61e54f60d721.png)

After:
![after](https://user-images.githubusercontent.com/1270500/66281486-946f5a80-e889-11e9-8793-0bdaac8d78cf.png)

