### PR TITLE
Missing items hackfix

### DIFF
--- a/PyTK/CustomElementHandler/CustomObjectData.cs
+++ b/PyTK/CustomElementHandler/CustomObjectData.cs
@@ -178,6 +178,10 @@ namespace PyTK.CustomElementHandler
             else
                 Game1.objectInformation.AddOrReplace(newIndex, data);
 
+            Dictionary<int, string> tmp = new Dictionary<int, string>();
+            tmp.Add(newIndex, data);
+            tmp.injectInto("Data\\BigCraftablesInformation");
+
             if (_sdvSourceRectangle.HasValue && OvSpritebatchNew.recCache.ContainsKey(_sdvSourceRectangle.Value))
                 OvSpritebatchNew.recCache.Remove(_sdvSourceRectangle.Value);
 

--- a/PyTK/CustomElementHandler/CustomObjectData.cs
+++ b/PyTK/CustomElementHandler/CustomObjectData.cs
@@ -173,14 +173,20 @@ namespace PyTK.CustomElementHandler
 
         public void forceNewSDVId(int newIndex)
         {
-            if (bigCraftable)
-                Game1.bigCraftablesInformation.AddOrReplace(newIndex, data);
-            else
-                Game1.objectInformation.AddOrReplace(newIndex, data);
-
             Dictionary<int, string> tmp = new Dictionary<int, string>();
             tmp.Add(newIndex, data);
-            tmp.injectInto("Data\\BigCraftablesInformation");
+
+            if (bigCraftable)
+            {
+                Game1.bigCraftablesInformation.AddOrReplace(newIndex, data);
+                tmp.injectInto("Data\\BigCraftablesInformation");
+            }
+            else
+            {
+                Game1.objectInformation.AddOrReplace(newIndex, data);
+                tmp.injectInto("Data\\ObjectInformation");
+            }
+
 
             if (_sdvSourceRectangle.HasValue && OvSpritebatchNew.recCache.ContainsKey(_sdvSourceRectangle.Value))
                 OvSpritebatchNew.recCache.Remove(_sdvSourceRectangle.Value);


### PR DESCRIPTION
Apparently there's a problem where late IAssetEditor's (such as JA) will clear CEH's edits to big craftables and objects. This makes it inject the changes using IAssetEditor as well, so that the changes persist once the data containers are refreshed.

Draft PR because this is more just a way I got it to work. I figure you probably will implement it differently.