### PR TITLE
Make TMXLoader call Json Asset's API to fix IDs in custom locations.

### DIFF
--- a/TMXLoader/Other/IJsonAssetsAPI.cs
+++ b/TMXLoader/Other/IJsonAssetsAPI.cs
@@ -1,0 +1,16 @@
+﻿using StardewValley;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TMXLoader.Other
+{
+    public interface IJsonAssetsAPI
+    {
+        bool FixIdsInItem(Item item);
+        void FixIdsInItemList(List<Item> items);
+        void FixIdsInLocation(GameLocation location);
+    }
+}

--- a/TMXLoader/TMXLoader.csproj
+++ b/TMXLoader/TMXLoader.csproj
@@ -42,6 +42,7 @@
   <ItemGroup>
     <Compile Include="BuildableEdit.cs" />
     <Compile Include="BuildableTranslation.cs" />
+    <Compile Include="Other\IJsonAssetsAPI.cs" />
     <Compile Include="SaveBuildable.cs" />
     <Compile Include="TMXAssetEditor.cs" />
     <Compile Include="Compatibility\CustomFarmTypes.cs" />

--- a/TMXLoader/TMXLoaderMod.cs
+++ b/TMXLoader/TMXLoaderMod.cs
@@ -24,6 +24,7 @@ using xTile.Dimensions;
 using StardewValley.TerrainFeatures;
 using xTile.Layers;
 using System.Collections;
+using TMXLoader.Other;
 
 namespace TMXLoader
 {
@@ -245,6 +246,7 @@ namespace TMXLoader
             if (!Game1.IsMasterGame)
                 return;
 
+            var ja = Helper.ModRegistry.GetApi<IJsonAssetsAPI>("spacechase0.JsonAssets");
             saveData = Helper.Data.ReadSaveData<SaveData>("Locations");
             if (saveData != null)
             {
@@ -253,10 +255,14 @@ namespace TMXLoader
                     Monitor.Log("Restore Location objects: " + loc.Name);
 
                     setLocationObejcts(loc);
+                    ja.FixIdsInLocation(Game1.getLocationFromName(loc.Name));
                 }
 
                 foreach (var b in saveData.Buildables)
+                {
                     loadSavedBuildable(b);
+                    ja.FixIdsInLocation(Game1.getLocationFromName(b.Indoors.Name));
+                }
             }
         }
 

--- a/TMXLoader/TMXLoaderMod.cs
+++ b/TMXLoader/TMXLoaderMod.cs
@@ -255,13 +255,15 @@ namespace TMXLoader
                     Monitor.Log("Restore Location objects: " + loc.Name);
 
                     setLocationObejcts(loc);
-                    ja.FixIdsInLocation(Game1.getLocationFromName(loc.Name));
+                    if (ja != null)
+                        ja.FixIdsInLocation(Game1.getLocationFromName(loc.Name));
                 }
 
                 foreach (var b in saveData.Buildables)
                 {
                     loadSavedBuildable(b);
-                    ja.FixIdsInLocation(Game1.getLocationFromName(b.Indoors.Name));
+                    if (ja != null)
+                        ja.FixIdsInLocation(Game1.getLocationFromName(b.Indoors.Name));
                 }
             }
         }


### PR DESCRIPTION
TMXLoader does all this after JA has already fixed IDs, so it needs to be explicitly called for the custom locations.

(Items will scramble when new packs get added/removed without this.)