### PR TITLE
Add null coalescing op.

### DIFF
--- a/PyTK/PyTKMod.cs
+++ b/PyTK/PyTKMod.cs
@@ -79,8 +79,8 @@ namespace PyTK
                 if (ReInjectCustomObjects)
                 {
                     ReInjectCustomObjects = false;
-                    CustomObjectData.injector.Invalidate();
-                    CustomObjectData.injectorBig.Invalidate();
+                    CustomObjectData.injector?.Invalidate();
+                    CustomObjectData.injectorBig?.Invalidate();
                 }
             };
 


### PR DESCRIPTION
It appears the injector objects aren't loaded during day start in some instances.  Added a simple null check.

I don't know enough about the logic of the injectors to know if this invalidation is just happening too early, and therefore checking for null isn't enough and the logic needs to be moved further down the event, but I'll leave that to Plat to figure though.  This removes the crash from my game and seems to allow CustomFarming to work correctly.