### PR TITLE
fix second page of channel list in CustomTV

### DIFF
--- a/PyTK/CustomTV/CustomTVMod.cs
+++ b/PyTK/CustomTV/CustomTVMod.cs
@@ -139,8 +139,6 @@ namespace PyTK.CustomTV
             {
                 if (defaults.Contains(id)) { continue; }
 
-                responses.Add(new Response(id, channels[id].text));
-
                 if (responses.Count > 7)
                 {
                     if (!responses.Contains(more))
@@ -153,6 +151,7 @@ namespace PyTK.CustomTV
                     responses = new List<Response>();
                 }
 
+                responses.Add(new Response(id, channels[id].text));
             }
 
             if (!responses.Contains(leave))
@@ -246,7 +245,7 @@ namespace PyTK.CustomTV
             Monitor.Log("Select Channel:" + a, LogLevel.Trace);
 
             if (a == "more")
-                showChannels(currentpage + 1);
+                PyUtils.setDelayedAction (0, () => showChannels(currentpage + 1));
             else if (channels.ContainsKey(a))
                 channels[a].action.Invoke(tv, tvScreen, who, a);
         }


### PR DESCRIPTION
When there were exactly 8 responses, the "(More)" line was being added but pointing to an empty second page. Moving that check to the beginning of the next loop creates a second page only with 9+ responses.

On second (and presumably later) pages, the afterQuestion callback was getting wiped out by the game code after the "(More)" response callback finished but before the second page was displayed, so nothing on the second page worked. Fixed by showing the second page from a zero-time DelayedAction to break out of the callback stack.