### PR TITLE
CustomTV: fit channel list to screen on Android

### DIFF
--- a/PyTK/CustomTV/CustomTVMod.cs
+++ b/PyTK/CustomTV/CustomTVMod.cs
@@ -49,6 +49,7 @@ namespace PyTK.CustomTV
 
         private static TV tv;
 
+        private static int channelsPerPage = (Constants.TargetPlatform == GamePlatform.Android) ? 3 : 8;
         private static int currentpage = 0;
         private static List<List<Response>> pages = new List<List<Response>>();
         internal static Dictionary<string, TVChannel> channels = new Dictionary<string, TVChannel>();
@@ -139,7 +140,7 @@ namespace PyTK.CustomTV
             {
                 if (defaults.Contains(id)) { continue; }
 
-                if (responses.Count > 7)
+                if (responses.Count >= channelsPerPage)
                 {
                     if (!responses.Contains(more))
                         responses.Add(more);


### PR DESCRIPTION
When the "(More)" and "(Leave)" responses are included, on Android there is only room on screen for three channels at a time. The zoom is temporarily reset on Android while displaying dialogues, so this number will always work.