### PR TITLE
TMXLoader: Fix custom location class (de)serialization

### DIFF
--- a/TMXLoader/SerializationFix.cs
+++ b/TMXLoader/SerializationFix.cs
@@ -11,6 +11,7 @@ namespace TMXLoader
 {
     internal static class SerializationFix
     {
+        // This list must be kept in sync with StardewValley.SaveGame.locationSerializer.
         public static Type[] ExtraTypes = new Type[24]
         {
             typeof(Tool),
@@ -44,6 +45,7 @@ namespace TMXLoader
             Type baseType = typeof(GameLocation);
             Type customType = location.GetType();
 
+            // No need to fix types from the base game.
             if (object.ReferenceEquals(customType.Assembly, baseType.Assembly))
             {
                 SaveGame.locationSerializer.Serialize(writer, location);
@@ -52,10 +54,12 @@ namespace TMXLoader
 
             var xmlOverrides = new XmlAttributeOverrides();
 
+            // Move the base type out of the way to make its name available.
             var baseAttribs = new XmlAttributes();   
             baseAttribs.XmlType = new XmlTypeAttribute("GameLocation1");
             xmlOverrides.Add(baseType, baseAttribs);
 
+            // Make sure the custom type saves with the base name so it will deserialize correctly.
             var customAttribs = new XmlAttributes();   
             customAttribs.XmlType = new XmlTypeAttribute("GameLocation");
             xmlOverrides.Add(customType, customAttribs);

--- a/TMXLoader/SerializationFix.cs
+++ b/TMXLoader/SerializationFix.cs
@@ -1,0 +1,67 @@
+using StardewValley;
+using StardewValley.Characters;
+using StardewValley.Monsters;
+using StardewValley.Objects;
+using StardewValley.TerrainFeatures;
+using System;
+using System.Xml;
+using System.Xml.Serialization;
+
+namespace TMXLoader
+{
+    internal static class SerializationFix
+    {
+        public static Type[] ExtraTypes = new Type[24]
+        {
+            typeof(Tool),
+            typeof(Duggy),
+            typeof(Ghost),
+            typeof(GreenSlime),
+            typeof(LavaCrab),
+            typeof(RockCrab),
+            typeof(ShadowGuy),
+            typeof(Child),
+            typeof(Pet),
+            typeof(Dog),
+            typeof(Cat),
+            typeof(Horse),
+            typeof(SquidKid),
+            typeof(Grub),
+            typeof(Fly),
+            typeof(DustSpirit),
+            typeof(Bug),
+            typeof(BigSlime),
+            typeof(BreakableContainer),
+            typeof(MetalHead),
+            typeof(ShadowGirl),
+            typeof(Monster),
+            typeof(JunimoHarvester),
+            typeof(TerrainFeature)
+        };
+
+        public static void SafeSerialize(XmlWriter writer, GameLocation location)
+        {
+            Type baseType = typeof(GameLocation);
+            Type customType = location.GetType();
+
+            if (object.ReferenceEquals(customType.Assembly, baseType.Assembly))
+            {
+                SaveGame.locationSerializer.Serialize(writer, location);
+                return;
+            }
+
+            var xmlOverrides = new XmlAttributeOverrides();
+
+            var baseAttribs = new XmlAttributes();   
+            baseAttribs.XmlType = new XmlTypeAttribute("GameLocation1");
+            xmlOverrides.Add(baseType, baseAttribs);
+
+            var customAttribs = new XmlAttributes();   
+            customAttribs.XmlType = new XmlTypeAttribute("GameLocation");
+            xmlOverrides.Add(customType, customAttribs);
+
+            XmlSerializer serializer = new XmlSerializer(customType, xmlOverrides, ExtraTypes, null, null);
+            serializer.Serialize(writer, location);
+        }
+    }
+}

--- a/TMXLoader/TMXLoaderMod.cs
+++ b/TMXLoader/TMXLoaderMod.cs
@@ -158,62 +158,11 @@ namespace TMXLoader
 
             helper.Events.Player.Warped += Player_Warped;
 
+            helper.Events.GameLoop.SaveCreating += (s, e) => beforeSave();
+            helper.Events.GameLoop.Saving += (s, e) => beforeSave();
 
-            helper.Events.GameLoop.Saving += (s, e) =>
-            {
-
-                if (Game1.IsMasterGame)
-                {
-                    saveData = new SaveData();
-                    saveData.Locations = new List<SaveLocation>();
-                    saveData.Buildables = new List<SaveBuildable>();
-                    saveData.Data = new List<PersistentData>();
-
-                    foreach (var l in addedLocations)
-                        if (Game1.getLocationFromName(l.name) is GameLocation location && getLocationSaveData(location) is SaveLocation sav)
-                            saveData.Locations.Add(sav);
-
-                    foreach (var b in buildablesBuild)
-                    {
-                        BuildableEdit edit = buildables.Find(be => be.id == b.Id);
-
-                        if (edit.indoorsFile != null && Game1.getLocationFromName(getLocationName(b.UniqueId)) is GameLocation location && getLocationSaveData(location) is SaveLocation sav)
-                            b.Indoors = sav;
-
-                        saveData.Buildables.Add(b);
-                    }
-
-                    foreach (GameLocation location in Game1.locations)
-                        if (location.Map.Properties.TryGetValue("PersistentData", out PropertyValue dataString)
-                        && dataString != null
-                        && dataString.ToString().Split(':') is string[] data && data.Length == 3)
-                            saveData.Data.Add(new PersistentData(data[0], data[1], data[2]));
-
-                    Helper.Data.WriteSaveData<SaveData>("Locations", saveData);
-                }
-
-                locationStorage.Clear();
-
-                foreach (var l in addedLocations)
-                    if (Game1.getLocationFromName(l.name) is GameLocation location)
-                    {
-                        Game1.locations.Remove(location);
-                        locationStorage.Add(location);
-                    }
-
-                foreach (var b in buildablesBuild)
-                    if (buildables.Find(be => be.id == b.Id) is BuildableEdit edit && edit.indoorsFile != null && Game1.getLocationFromName(getLocationName(b.UniqueId)) is GameLocation location)
-                    {
-                        Game1.locations.Remove(location);
-                        locationStorage.Add(location);
-                    }
-
-            };
-
-            helper.Events.GameLoop.Saved += (s, e) => {
-                foreach (var loc in locationStorage)
-                    Game1.locations.Add(loc);
-            };
+            helper.Events.GameLoop.SaveCreated += (s, e) => afterSave();
+            helper.Events.GameLoop.Saved += (s, e) => afterSave();
 
             helper.Events.GameLoop.DayStarted += (s, e) =>
             {
@@ -231,6 +180,61 @@ namespace TMXLoader
             };
 
             helper.Events.Display.MenuChanged += TMXActions.updateItemListAfterShop;
+        }
+
+        private void beforeSave()
+        {
+            if (Game1.IsMasterGame)
+            {
+                saveData = new SaveData();
+                saveData.Locations = new List<SaveLocation>();
+                saveData.Buildables = new List<SaveBuildable>();
+                saveData.Data = new List<PersistentData>();
+
+                foreach (var l in addedLocations)
+                    if (Game1.getLocationFromName(l.name) is GameLocation location && getLocationSaveData(location) is SaveLocation sav)
+                        saveData.Locations.Add(sav);
+
+                foreach (var b in buildablesBuild)
+                {
+                    BuildableEdit edit = buildables.Find(be => be.id == b.Id);
+
+                    if (edit.indoorsFile != null && Game1.getLocationFromName(getLocationName(b.UniqueId)) is GameLocation location && getLocationSaveData(location) is SaveLocation sav)
+                        b.Indoors = sav;
+
+                    saveData.Buildables.Add(b);
+                }
+
+                foreach (GameLocation location in Game1.locations)
+                    if (location.Map.Properties.TryGetValue("PersistentData", out PropertyValue dataString)
+                    && dataString != null
+                    && dataString.ToString().Split(':') is string[] data && data.Length == 3)
+                        saveData.Data.Add(new PersistentData(data[0], data[1], data[2]));
+
+                Helper.Data.WriteSaveData<SaveData>("Locations", saveData);
+            }
+
+            locationStorage.Clear();
+
+            foreach (var l in addedLocations)
+                if (Game1.getLocationFromName(l.name) is GameLocation location)
+                {
+                    Game1.locations.Remove(location);
+                    locationStorage.Add(location);
+                }
+
+            foreach (var b in buildablesBuild)
+                if (buildables.Find(be => be.id == b.Id) is BuildableEdit edit && edit.indoorsFile != null && Game1.getLocationFromName(getLocationName(b.UniqueId)) is GameLocation location)
+                {
+                    Game1.locations.Remove(location);
+                    locationStorage.Add(location);
+                }
+        }
+
+        private void afterSave()
+        {
+            foreach (var loc in locationStorage)
+                Game1.locations.Add(loc);
         }
 
         private void restoreAllSavedBuildables()

--- a/TMXLoader/TMXLoaderMod.cs
+++ b/TMXLoader/TMXLoaderMod.cs
@@ -688,8 +688,8 @@ namespace TMXLoader
                 }
                 catch (Exception e)
                 {
-                    Monitor.Log("Failed to deserialize: " + loc.Name, LogLevel.Trace);
-                    Monitor.Log(e.Message);
+                    Monitor.Log("Failed to deserialize: " + loc.Name, LogLevel.Warn);
+                    Monitor.Log(e.Message, LogLevel.Info);
                     monitor.Log(e.StackTrace);
                     return false;
                 }
@@ -746,13 +746,12 @@ namespace TMXLoader
             {
                 try
                 {
-
-                    SaveGame.locationSerializer.Serialize(writer, location);
+                    SerializationFix.SafeSerialize(writer, location);
                 }
                 catch (Exception e)
                 {
-                    Monitor.Log("Failed to serialize: " + location.Name, LogLevel.Trace);
-                    Monitor.Log(e.Message);
+                    Monitor.Log("Failed to serialize: " + location.Name, LogLevel.Warn);
+                    Monitor.Log(e.Message, LogLevel.Info);
                     monitor.Log(e.StackTrace);
                     return null;
                 }

--- a/TMXLoader/TMXLoaderMod.cs
+++ b/TMXLoader/TMXLoaderMod.cs
@@ -256,7 +256,7 @@ namespace TMXLoader
                 {
                     Monitor.Log("Restore Location objects: " + loc.Name);
 
-                    setLocationObejcts(loc);
+                    setLocationObjects(loc);
                     try
                     {
                         if (ja != null && Game1.getLocationFromName(loc.Name) is GameLocation location)
@@ -364,7 +364,7 @@ namespace TMXLoader
 
                 buildBuildableEdit(false, edit, location, new Point(b.Position[0], b.Position[1]), b.Colors, b.UniqueId, b.PlayerName, b.PlayerId, false);
                 if (b.Indoors != null)
-                    setLocationObejcts(b.Indoors);
+                    setLocationObjects(b.Indoors);
 
             }
         }
@@ -517,7 +517,7 @@ namespace TMXLoader
                     {
                         var locSaveData = savd;
                         locSaveData.Name = getLocationName(uniqueId);
-                        setLocationObejcts(locSaveData);
+                        setLocationObjects(locSaveData);
                     }
 
                     removeSavedBuildable(sb, pay, distribute);
@@ -667,7 +667,7 @@ namespace TMXLoader
             return map;
         }
 
-        private bool setLocationObejcts(SaveLocation loc)
+        private bool setLocationObjects(SaveLocation loc)
         {
             XmlReaderSettings settings = new XmlReaderSettings();
             settings.ConformanceLevel = ConformanceLevel.Auto;


### PR DESCRIPTION
Without these fixes, all locations created by TMXLoader fail to have their SaveData handled properly on the first night (save creation transitioning from intro/"day zero" to day one). Locations with custom classes using `"type": "Custom:..."` further fail to serialize at all. The combination of the two issues leads to new save creation locking up when a mod with a custom location class is installed.