### PR TITLE
TMXL: compatibility with Save Anywhere

### DIFF
--- a/TMXLoader/Compatibility/SaveAnywhereAPI.cs
+++ b/TMXLoader/Compatibility/SaveAnywhereAPI.cs
@@ -1,0 +1,67 @@
+using System;
+
+namespace Omegasis.SaveAnywhere.Framework
+{
+    /// <summary>
+    ///     Interface for the Save Anywhere API
+    ///     Other mods can use this interface to get the
+    ///         API from the SMAPI helper
+    /// </summary>
+    public interface ISaveAnywhereAPI
+    {
+
+        /*********
+		** Events
+		*********/
+        /// <summary>
+        ///     Event that fires before game save
+        /// </summary>
+        event EventHandler BeforeSave;
+        /// <summary>
+        ///     Event that fires after game save
+        /// </summary>
+        event EventHandler AfterSave;
+        /// <summary>
+        ///     Event that fires after game load
+        /// </summary>
+        event EventHandler AfterLoad;
+
+        /// <summary>
+        /// Add in an event that can trigger before saving begins.
+        /// </summary>
+        /// <param name="ID"></param>
+        /// <param name="BeforeSave"></param>
+        void addBeforeSaveEvent(string ID, Action BeforeSave);
+        /// <summary>
+        /// Remove an event that can trigger before saving begins.
+        /// </summary>
+        /// <param name="ID"></param>
+        /// <param name="BeforeSave"></param>
+        void removeBeforeSaveEvent(string ID, Action BeforeSave);
+        /// <summary>
+        /// Add an event that tiggers after saving has finished.
+        /// </summary>
+        /// <param name="ID"></param>
+        /// <param name="AfterSave"></param>
+        void addAfterSaveEvent(string ID, Action AfterSave);
+        /// <summary>
+        ///Remove an event that triggers after saving has occured.
+        /// </summary>
+        /// <param name="ID"></param>
+        /// <param name="AfterSave"></param>
+        void removeAfterSaveEvent(string ID, Action AfterSave);
+        /// <summary>
+        /// Add in an event that triggers afer loading has occured.
+        /// </summary>
+        /// <param name="ID"></param>
+        /// <param name="AfterLoad"></param>
+        void addAfterLoadEvent(string ID, Action AfterLoad);
+        /// <summary>
+        /// Remove an event that occurs after loading has occured.
+        /// </summary>
+        /// <param name="ID"></param>
+        /// <param name="AfterLoad"></param>
+        void removeAfterLoadEvent(string ID, Action AfterLoad);
+
+    }
+}

--- a/TMXLoader/TMXLoaderMod.cs
+++ b/TMXLoader/TMXLoaderMod.cs
@@ -945,6 +945,14 @@ namespace TMXLoader
             harmonyFix();
 
             helper.Events.GameLoop.UpdateTicked += GameLoop_UpdateTicked;
+
+            var SaveAnywhere = helper.ModRegistry.GetApi<Omegasis.SaveAnywhere.Framework.ISaveAnywhereAPI>("Omegasis.SaveAnywhere");
+            if (SaveAnywhere != null)
+            {
+                SaveAnywhere.BeforeSave += (_s, _e) => beforeSave();
+                SaveAnywhere.AfterSave += (_s, _e) => afterSave();
+                SaveAnywhere.AfterLoad += (_s, _e) => SavePatch();
+            }
         }
 
         private void GameLoop_UpdateTicked(object sender, UpdateTickedEventArgs e)


### PR DESCRIPTION
This change prevents crashes with custom-classed locations and lost data with all TMXL locations. There is still something odd about the result, because `debug warp` fails to find TMXL locations if a Save Anywhere save has been performed without an intervening exit to title. Player-facing functionality seems to be fine, though.