### PR TITLE
JA-style API Method for getting the names of all furniture in a given content pack.

### DIFF
--- a/CustomFurniture/Api.cs
+++ b/CustomFurniture/Api.cs
@@ -1,0 +1,34 @@
+﻿using System.Collections.Generic;
+
+namespace CustomFurniture
+{
+  public interface IApi
+  {
+    List<string> GetAllFurnitureFromContentPack(string cp);
+  }
+
+  public class Api : IApi
+  {
+    /// <summary>
+    /// Given the unique id of a content pack, return a list of all furniture
+    /// item names defined by that content pack.
+    /// </summary>
+    /// <param name="cpUniqueId">The unique id of a content pack,
+    /// e.g. Platonymous.ExamplePack</param>
+    /// <returns>List of furniture names, or null if the content pack was
+    /// unknown to us.</returns>
+    public List<string> GetAllFurnitureFromContentPack(string cpUniqueId)
+    {
+      foreach (var entry in ((CustomFurnitureMod)CustomFurnitureMod.instance).
+                 furnitureByContentPack)
+      {
+        if (entry.Key.UniqueID == cpUniqueId)
+        {
+          return new List<string>(entry.Value);
+        }
+      }
+      return null;
+    }
+
+  }
+}

--- a/CustomFurniture/CustomFurnitureMod.cs
+++ b/CustomFurniture/CustomFurnitureMod.cs
@@ -127,6 +127,12 @@ namespace CustomFurniture
             Helper.Events.Display.MenuChanged += OnMenuChanged;
         }
 
+        private Api api;
+        public override object GetApi()
+        {
+            return api ?? (api = new Api());
+        }
+
         public Dictionary<IManifest, List<string>> furnitureByContentPack =
           new Dictionary<IManifest, List<string>>();
 

--- a/CustomFurniture/CustomFurnitureMod.cs
+++ b/CustomFurniture/CustomFurnitureMod.cs
@@ -127,6 +127,9 @@ namespace CustomFurniture
             Helper.Events.Display.MenuChanged += OnMenuChanged;
         }
 
+        public Dictionary<IManifest, List<string>> furnitureByContentPack =
+          new Dictionary<IManifest, List<string>>();
+
         private void loadPacks()
         {
             int countPacks = 0;
@@ -151,6 +154,10 @@ namespace CustomFurniture
                     pack.version = cpack.Manifest.Version.ToString();
                     string author = pack.author == "none" ? "" : " by " + pack.author;
                     Monitor.Log(pack.name + " " + pack.version + author, LogLevel.Info);
+                    if (!furnitureByContentPack.ContainsKey(cpack.Manifest))
+                    {
+                      furnitureByContentPack.Add(cpack.Manifest, new List<string>());
+                    }
                     foreach (CustomFurnitureData data in pack.furniture)
                     {
                         countObjects++;
@@ -164,6 +171,7 @@ namespace CustomFurniture
                         CustomFurniture f = new CustomFurniture(data, objectID, Vector2.Zero);
                         furniturePile.AddOrReplace(pileID, f);
                         furniture.AddOrReplace(objectID, f);
+                        furnitureByContentPack[cpack.Manifest].Add(f.name);
                     }
                 }
 


### PR DESCRIPTION
Introduces an API class with a single method to return, given the unique id of a content pack, a list of all furniture names defined by that content pack.

The intent of providing this API method is to facilitate integration with ChroniclerCherry's ShopTileFramework, allowing custom furniture to be sold in shops other than Robin's carpentry shop.