### PR TITLE
Fix the missing key error for placement restriction

### DIFF
--- a/CustomFurniture/CustomFurniture.cs
+++ b/CustomFurniture/CustomFurniture.cs
@@ -61,6 +61,7 @@ namespace CustomFurniture
             tileLocation.Value = tile;
 
             CustomFurnitureMod.helper.Reflection.GetField<string>(this, "_description").SetValue(data.description);
+            CustomFurnitureMod.helper.Reflection.GetField<int>(this, "_placementRestriction").SetValue(2);
 
             parentSheetIndex.Set(data.index);
             setTexture();

--- a/CustomFurniture/manifest.json
+++ b/CustomFurniture/manifest.json
@@ -1,7 +1,7 @@
 {
   "Name": "Custom Furniture",
   "Author": "Platonymous",
-  "Version": "0.11.2",
+  "Version": "0.11.3-unofficial-1",
   "Description": "Helper Mod for Custom Furniture creation.",
   "UniqueID": "Platonymous.CustomFurniture",
   "EntryDll": "CustomFurniture.dll",


### PR DESCRIPTION
Fix for errors that occur on CF in regards to dictionary key not found.

Error prior to fix:
----
[SMAPI] The StardewValley.Menus.ShopMenu menu crashed while drawing itself. SMAPI will force it to exit to avoid crashing the game.
System.Collections.Generic.KeyNotFoundException: The given key was not present in the dictionary.
   at System.Collections.Generic.Dictionary`2.get_Item(TKey key)
   at StardewValley.Objects.Furniture.getData() in C:\GitlabRunner\builds\Gq5qA5P4\0\ConcernedApe\stardewvalley\Farmer\Farmer\Objects\Furniture.cs:line 215
   at StardewValley.Objects.Furniture.get_placementRestriction() in C:\GitlabRunner\builds\Gq5qA5P4\0\ConcernedApe\stardewvalley\Farmer\Farmer\Objects\Furniture.cs:line 93
   at StardewValley.Object.getCategoryName() in C:\GitlabRunner\builds\Gq5qA5P4\0\ConcernedApe\stardewvalley\Farmer\Farmer\Objects\Object.cs:line 3434
   at StardewValley.Menus.IClickableMenu.drawHoverText(SpriteBatch b, StringBuilder text, SpriteFont font, Int32 xOffset, Int32 yOffset, Int32 moneyAmountToDisplayAtBottom, String boldTitleText, Int32 healAmountToDisplay, String[] buffIconsToDisplay, Item hoveredItem, Int32 currencySymbol, Int32 extraItemToShowIndex, Int32 extraItemToShowAmount, Int32 overrideX, Int32 overrideY, Single alpha, CraftingRecipe craftingIngredients, IList`1 additional_craft_materials) in C:\GitlabRunner\builds\Gq5qA5P4\0\ConcernedApe\stardewvalley\Farmer\Farmer\Menus\IClickableMenu.cs:line 1074
   at StardewValley.Menus.IClickableMenu.drawHoverText(SpriteBatch b, String text, SpriteFont font, Int32 xOffset, Int32 yOffset, Int32 moneyAmountToDisplayAtBottom, String boldTitleText, Int32 healAmountToDisplay, String[] buffIconsToDisplay, Item hoveredItem, Int32 currencySymbol, Int32 extraItemToShowIndex, Int32 extraItemToShowAmount, Int32 overrideX, Int32 overrideY, Single alpha, CraftingRecipe craftingIngredients, IList`1 additional_craft_materials) in C:\GitlabRunner\builds\Gq5qA5P4\0\ConcernedApe\stardewvalley\Farmer\Farmer\Menus\IClickableMenu.cs:line 1026
   at StardewValley.Menus.IClickableMenu.drawToolTip_PatchedBy<SMAPI>(SpriteBatch b, String hoverText, String hoverTitle, Item hoveredItem, Boolean heldItem, Int32 healAmountToDisplay, Int32 currencySymbol, Int32 extraItemToShowIndex, Int32 extraItemToShowAmount, CraftingRecipe craftingIngredients, Int32 moneyAmountToShowAtBottom)
   at StardewValley.Menus.ShopMenu.draw(SpriteBatch b) in C:\GitlabRunner\builds\Gq5qA5P4\0\ConcernedApe\stardewvalley\Farmer\Farmer\Menus\ShopMenu.cs:line 2209
   at StardewModdingAPI.Framework.SGame.DrawImpl(GameTime gameTime, RenderTarget2D target_screen) in C:\source\_Stardew\SMAPI\src\SMAPI\Framework\SGame.cs:line 912

----

StardewValley.Objects.Furniture.get_placementRestriction was the thing that broke the mod. 

This branch is a simple 1-liner fix to stop this error. It allows all furniture to be placed inside or out. From what I can gather, -1 = automatic, 0 = inside only, 1 = outside only, 2 = both.

NB: This PR does not implement sittable chairs from modded content. This is only to stop the mod from crashing games.