### PR TITLE
Update for Stardew Valley 1.5.5

### DIFF
--- a/2048ArcadeMachine/2048ArcadeMachine.csproj
+++ b/2048ArcadeMachine/2048ArcadeMachine.csproj
@@ -4,7 +4,7 @@
     <AssemblyName>_2048ArcadeMachine</AssemblyName>
     <RootNamespace>_2048ArcadeMachine</RootNamespace>
     <Version>1.0.0</Version>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <ModFolderName>[JA] Arcade2048</ModFolderName>
   </PropertyGroup>
 

--- a/ATM/ATM.csproj
+++ b/ATM/ATM.csproj
@@ -8,10 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="3.2.2" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\PyTK\PyTK.csproj" />
   </ItemGroup>
 

--- a/ATM/ATM.csproj
+++ b/ATM/ATM.csproj
@@ -3,12 +3,12 @@
   <PropertyGroup>
     <AssemblyName>ATM</AssemblyName>
     <RootNamespace>ATM</RootNamespace>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <Version>1.1.3</Version>
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\PyTK\PyTK.csproj" />
+    <ProjectReference Include="..\PyTK\PyTK.csproj" Private="false" />
   </ItemGroup>
 
   <Import Project="$(SolutionDir)\common.targets" />

--- a/Arcade2048/Arcade2048.csproj
+++ b/Arcade2048/Arcade2048.csproj
@@ -3,19 +3,13 @@
   <PropertyGroup>
     <AssemblyName>Arcade2048</AssemblyName>
     <RootNamespace>Arcade2048</RootNamespace>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <Version>1.4.1</Version>
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Platonymous.PlatoTK">
-      <HintPath>$(GamePath)\Mods\PlatoTK\PlatoTK.dll</HintPath>
-      <Private>False</Private>
-      <SpecificVersion>false</SpecificVersion>
-    </Reference>
+    <Reference Include="Platonymous.PlatoTK" HintPath="$(GamePath)\Mods\PlatoTK\PlatoTK.dll" Private="false" />
   </ItemGroup>
-
-
 
   <Import Project="$(SolutionDir)\common.targets" />
 

--- a/ArcadePong/ArcadePong.csproj
+++ b/ArcadePong/ArcadePong.csproj
@@ -3,14 +3,12 @@
   <PropertyGroup>
     <AssemblyName>ArcadePong</AssemblyName>
     <RootNamespace>ArcadePong</RootNamespace>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <Version>1.1.1</Version>
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\PyTK\PyTK.csproj">
-      <Private>false</Private>
-    </ProjectReference>
+    <ProjectReference Include="..\PyTK\PyTK.csproj" Private="false" />
   </ItemGroup>
 
   <Import Project="$(SolutionDir)\common.targets" />

--- a/ArcadePong/ArcadePongMod.cs
+++ b/ArcadePong/ArcadePongMod.cs
@@ -1,4 +1,4 @@
-﻿using Harmony;
+﻿using HarmonyLib;
 using StardewModdingAPI;
 using StardewModdingAPI.Events;
 using PyTK.Extensions;
@@ -24,7 +24,7 @@ namespace ArcadePong
         public override void Entry(IModHelper helper)
         {
             monitor = Monitor;
-            HarmonyInstance.Create("Platonymous.ArcadePong").PatchAll(Assembly.GetExecutingAssembly());
+            new Harmony("Platonymous.ArcadePong").PatchAll(Assembly.GetExecutingAssembly());
             helper.Events.GameLoop.SaveLoaded += (o, e) => setup();
             helper.Events.GameLoop.GameLaunched += (o, e ) => pdata = new CustomObjectData("Pong", "Pong/0/-300/Crafting -9/Play 'Pong by Cat' at home!/true/true/0/Pong", Game1.bigCraftableSpriteSheet.getTile(159, 16, 32).setSaturation(0).setLight(130), Color.Yellow, bigCraftable: true, type: typeof(PongMachine));
         }

--- a/ArcadeSnake/ArcadeSnake.csproj
+++ b/ArcadeSnake/ArcadeSnake.csproj
@@ -3,18 +3,13 @@
   <PropertyGroup>
     <AssemblyName>Snake</AssemblyName>
     <RootNamespace>Snake</RootNamespace>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <Version>1.4.0</Version>
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Platonymous.PlatoTK">
-      <HintPath>$(GamePath)\Mods\PlatoTK\PlatoTK.dll</HintPath>
-      <Private>False</Private>
-      <SpecificVersion>false</SpecificVersion>
-    </Reference>
+    <Reference Include="Platonymous.PlatoTK" HintPath="$(GamePath)\Mods\PlatoTK\PlatoTK.dll" Private="false" />
   </ItemGroup>
-
 
   <Import Project="$(SolutionDir)\common.targets" />
 

--- a/ArcadeSnake/SnakeMachine.cs
+++ b/ArcadeSnake/SnakeMachine.cs
@@ -2,7 +2,7 @@
 using StardewValley;
 using System;
 using System.Linq;
-using Harmony;
+using HarmonyLib;
 using StardewModdingAPI;
 
 namespace Snake

--- a/CFAutomate/CFAutomate.csproj
+++ b/CFAutomate/CFAutomate.csproj
@@ -3,24 +3,17 @@
   <PropertyGroup>
     <AssemblyName>CFAutomate</AssemblyName>
     <RootNamespace>CFAutomate</RootNamespace>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <Version>2.12.11</Version>
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\CustomFarmingRedux\CustomFarmingRedux.csproj">
-      <Private>false</Private>
-    </ProjectReference>
-    <ProjectReference Include="..\PyTK\PyTK.csproj">
-      <Private>false</Private>
-    </ProjectReference>
+    <ProjectReference Include="..\CustomFarmingRedux\CustomFarmingRedux.csproj" Private="false" />
+    <ProjectReference Include="..\PyTK\PyTK.csproj" Private="false" />
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="Automate">
-      <HintPath>$(GamePath)\Mods\Automate\Automate.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
+    <Reference Include="Automate" HintPath="$(GamePath)\Mods\Automate\Automate.dll" Private="false" />
   </ItemGroup>
 
   <Import Project="$(SolutionDir)\common.targets" />

--- a/ChessBoard/ChessBoard.csproj
+++ b/ChessBoard/ChessBoard.csproj
@@ -3,12 +3,12 @@
   <PropertyGroup>
     <AssemblyName>ChessBoard</AssemblyName>
     <RootNamespace>ChessBoard</RootNamespace>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <Version>0.10.0</Version>
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\PyTK\PyTK.csproj" />
+    <ProjectReference Include="..\PyTK\PyTK.csproj" Private="false" />
   </ItemGroup>
 
   <Import Project="$(SolutionDir)\common.targets" />

--- a/Comics/Comics.csproj
+++ b/Comics/Comics.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyName>Comics</AssemblyName>
     <RootNamespace>Comics</RootNamespace>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <Version>2.3.0</Version>
   </PropertyGroup>
 
@@ -12,13 +12,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="Platonymous.PlatoTK">
-      <HintPath>$(GamePath)\Mods\PlatoTK\PlatoTK.dll</HintPath>
-      <Private>False</Private>
-      <SpecificVersion>false</SpecificVersion>
-    </Reference>
+    <Reference Include="Platonymous.PlatoTK" HintPath="$(GamePath)\Mods\PlatoTK\PlatoTK.dll" Private="false" />
   </ItemGroup>
-
 
   <Import Project="$(SolutionDir)\common.targets" />
 

--- a/CropExtensions/CropExtensions.csproj
+++ b/CropExtensions/CropExtensions.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyName>CropExtensions</AssemblyName>
     <RootNamespace>CropExtensions</RootNamespace>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <Version>1.1.1</Version>
   </PropertyGroup>
 

--- a/CropExtensions/CropExtensionsMod.cs
+++ b/CropExtensions/CropExtensionsMod.cs
@@ -1,5 +1,5 @@
 ﻿using StardewModdingAPI;
-using Harmony;
+using HarmonyLib;
 using StardewValley;
 using StardewValley.TerrainFeatures;
 using System.Linq;
@@ -45,7 +45,7 @@ namespace CropExtensions
         public override void Entry(IModHelper helper)
         {
             config = helper.ReadConfig<Config>();
-            var instance = HarmonyInstance.Create("Platonymous.CropExtension");
+            var instance = new Harmony("Platonymous.CropExtension");
             instance.Patch(typeof(HoeDirt).GetMethod("plant"), null, new HarmonyMethod(this.GetType().GetMethod("plant")));
             instance.Patch(typeof(HoeDirt).GetMethod("canPlantThisSeedHere"), null, new HarmonyMethod(this.GetType().GetMethod("canPlantThisSeedHere")));
             instance.Patch(typeof(Crop).GetMethod("newDay"), new HarmonyMethod(this.GetType().GetMethod("newDay")));

--- a/CustomFarmingRedux/CustomFarmingRedux.csproj
+++ b/CustomFarmingRedux/CustomFarmingRedux.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyName>CustomFarmingRedux</AssemblyName>
     <RootNamespace>CustomFarmingRedux</RootNamespace>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <Version>2.12.11</Version>
   </PropertyGroup>
 
@@ -12,9 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\PyTK\PyTK.csproj">
-      <Private>false</Private>
-    </ProjectReference>
+    <ProjectReference Include="..\PyTK\PyTK.csproj" Private="false" />
   </ItemGroup>
 
   <Import Project="$(SolutionDir)\common.targets" />

--- a/CustomFurniture/CustomFurniture.csproj
+++ b/CustomFurniture/CustomFurniture.csproj
@@ -3,23 +3,18 @@
   <PropertyGroup>
     <AssemblyName>CustomFurniture</AssemblyName>
     <RootNamespace>CustomFurniture</RootNamespace>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <Version>0.12.0</Version>
   </PropertyGroup>
 
   <ItemGroup>
-    <Content Include="Furniture\non-cp-packs-go-here.txt">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
+    <Content Include="Furniture\non-cp-packs-go-here.txt" CopyToOutputDirectory="Always" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\PyTK\PyTK.csproj">
-      <Private>false</Private>
-    </ProjectReference>
+    <ProjectReference Include="..\PyTK\PyTK.csproj" Private="false" />
   </ItemGroup>
 
   <Import Project="$(SolutionDir)\common.targets" />
 
 </Project>
-

--- a/CustomFurniture/CustomFurnitureMod.cs
+++ b/CustomFurniture/CustomFurnitureMod.cs
@@ -8,7 +8,7 @@ using StardewValley.Menus;
 using System.Linq;
 using StardewValley.Objects;
 using System;
-using Harmony;
+using HarmonyLib;
 using System.Reflection;
 using Microsoft.Xna.Framework.Graphics;
 using PyTK.Extensions;
@@ -54,7 +54,7 @@ namespace CustomFurniture
 
         public void harmonyFix()
         {
-            var instance = HarmonyInstance.Create("Platonymous.CustomFurniture");
+            var instance = new Harmony("Platonymous.CustomFurniture");
             instance.PatchAll(Assembly.GetExecutingAssembly());
         }
 

--- a/CustomFurniture/Overrides/FurnitureFix.cs
+++ b/CustomFurniture/Overrides/FurnitureFix.cs
@@ -1,4 +1,4 @@
-﻿using Harmony;
+﻿using HarmonyLib;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using StardewValley;

--- a/CustomMovies/CustomMovies.csproj
+++ b/CustomMovies/CustomMovies.csproj
@@ -3,14 +3,15 @@
   <PropertyGroup>
     <AssemblyName>CustomMovies</AssemblyName>
     <RootNamespace>CustomMovies</RootNamespace>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <Version>0.9.4</Version>
 
     <EnableHarmony>true</EnableHarmony>
+    <BundleExtraAssemblies>ThirdParty</BundleExtraAssemblies>
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\PyTK\PyTK.csproj" />
+    <ProjectReference Include="..\PyTK\PyTK.csproj" Private="false" />
   </ItemGroup>
 
   <Import Project="$(SolutionDir)\common.targets" />

--- a/CustomMovies/CustomMovies.csproj
+++ b/CustomMovies/CustomMovies.csproj
@@ -5,6 +5,8 @@
     <RootNamespace>CustomMovies</RootNamespace>
     <TargetFramework>net452</TargetFramework>
     <Version>0.9.4</Version>
+
+    <EnableHarmony>true</EnableHarmony>
   </PropertyGroup>
 
   <ItemGroup>

--- a/CustomMovies/CustomMoviesMod.cs
+++ b/CustomMovies/CustomMoviesMod.cs
@@ -1,4 +1,4 @@
-﻿using Harmony;
+﻿using HarmonyLib;
 using Microsoft.Xna.Framework;
 using PyTK.Extensions;
 using StardewModdingAPI;
@@ -89,7 +89,7 @@ namespace CustomMovies
 
         private void harmonyFix()
         {
-            HarmonyInstance instance = HarmonyInstance.Create("Platonymous.CustomMovies");
+            Harmony instance = new Harmony("Platonymous.CustomMovies");
             instance.Patch(typeof(MovieTheater).GetMethod("GetMovieData", BindingFlags.Public | BindingFlags.Static), null, new HarmonyMethod(typeof(CustomMoviesMod).GetMethod("GetMovieData", BindingFlags.Public | BindingFlags.Static)), null);
             instance.Patch(typeof(MovieTheater).GetMethod("GetMovieForDate", BindingFlags.Public | BindingFlags.Static), null, new HarmonyMethod(typeof(CustomMoviesMod).GetMethod("GetMovieForDate", BindingFlags.Public | BindingFlags.Static)), null);
             instance.Patch(typeof(MovieTheater).GetMethod("GetMovieReactions", BindingFlags.Public | BindingFlags.Static), null, new HarmonyMethod(typeof(CustomMoviesMod).GetMethod("GetMovieReactions", BindingFlags.Public | BindingFlags.Static)), null);

--- a/CustomMovies/packages.config
+++ b/CustomMovies/packages.config
@@ -1,5 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Lib.Harmony" version="1.2.0.1" targetFramework="net45" />
-  <package id="Pathoschild.Stardew.ModBuildConfig" version="3.0.0-beta.7" targetFramework="net45" />
-</packages>

--- a/CustomMusic/CustomMusic.csproj
+++ b/CustomMusic/CustomMusic.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyName>CustomMusic</AssemblyName>
     <RootNamespace>CustomMusic</RootNamespace>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <Version>1.8.1</Version>
   </PropertyGroup>
 

--- a/CustomMusic/CustomMusicMod.cs
+++ b/CustomMusic/CustomMusicMod.cs
@@ -2,7 +2,7 @@
 using System.IO;
 using Microsoft.Xna.Framework.Audio;
 using Ogg2XNA;
-using Harmony;
+using HarmonyLib;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using System.Linq;
@@ -43,7 +43,7 @@ namespace CustomMusic
             SHelper = Helper;
             Thread thread = new Thread(loadContentPacks);
             thread.Start();
-            var harmony = HarmonyInstance.Create("Platonymous.CustomMusic");
+            var harmony = new Harmony("Platonymous.CustomMusic");
             harmony.Patch(typeof(Cue).GetMethod("Stop"), new HarmonyMethod(typeof(Overrides), "Stop"));
             harmony.Patch(typeof(Cue).GetMethod("Play"), new HarmonyMethod(typeof(Overrides), "Play"));
             harmony.Patch(typeof(Cue).GetMethod("Dispose"), new HarmonyMethod(typeof(Overrides), "Dispose"));

--- a/CustomTV/CustomTV.csproj
+++ b/CustomTV/CustomTV.csproj
@@ -3,13 +3,13 @@
   <PropertyGroup>
     <AssemblyName>CustomTV</AssemblyName>
     <RootNamespace>CustomTV</RootNamespace>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <Version>1.3.0</Version>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Platonymous.PlatoTK" Version="1.8.8" />
+    <Reference Include="Platonymous.PlatoTK" HintPath="$(GamePath)\Mods\PlatoTK\PlatoTK.dll" Private="false" />
   </ItemGroup>
 
   <Import Project="$(SolutionDir)\common.targets" />

--- a/CustomTVTemplate/CustomTVTemplate.csproj
+++ b/CustomTVTemplate/CustomTVTemplate.csproj
@@ -4,21 +4,13 @@
     <AssemblyName>CustomTVTemplate</AssemblyName>
     <RootNamespace>CustomTVTemplate</RootNamespace>
     <Version>1.0.0</Version>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
 </PropertyGroup>
 
   <Import Project="$(SolutionDir)\contentpacks.targets" />
 
   <ItemGroup>
-    <None Update="data\screens.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="data\meta.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="data\episodes.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
+    <None Update="data\*.json" CopyToOutputDirectory="Always" />
   </ItemGroup>
 
 </Project>

--- a/CustomWallsAndFloorsRedux/CustomWallsAndFloorsMod.cs
+++ b/CustomWallsAndFloorsRedux/CustomWallsAndFloorsMod.cs
@@ -1,4 +1,4 @@
-﻿using Harmony;
+﻿using HarmonyLib;
 using StardewModdingAPI;
 using StardewModdingAPI.Events;
 using StardewValley;
@@ -159,7 +159,7 @@ namespace CustomWallsAndFloorsRedux
             }, 100, SerializationType.JSON);
             wallpaperReceiver.start();
 
-            var harmony = HarmonyInstance.Create("Platonymous.CustomWallsAndFloorsRedux");
+            var harmony = new Harmony("Platonymous.CustomWallsAndFloorsRedux");
             harmony.Patch(typeof(GameLocation).GetMethod("setMapTileIndex", BindingFlags.Public | BindingFlags.Instance), new HarmonyMethod(GetType().GetMethod("setMapTileIndexPrefix", BindingFlags.Public | BindingFlags.Static)), new HarmonyMethod(GetType().GetMethod("setMapTileIndex", BindingFlags.Public | BindingFlags.Static)));
             harmony.Patch(typeof(Wallpaper).GetMethod("placementAction", BindingFlags.Public | BindingFlags.Instance), prefix: new HarmonyMethod(GetType().GetMethod("placementAction", BindingFlags.Public | BindingFlags.Static)));
 

--- a/CustomWallsAndFloorsRedux/CustomWallsAndFloorsRedux.csproj
+++ b/CustomWallsAndFloorsRedux/CustomWallsAndFloorsRedux.csproj
@@ -3,14 +3,12 @@
   <PropertyGroup>
     <AssemblyName>CustomWallsAndFloorsRedux</AssemblyName>
     <RootNamespace>CustomWallsAndFloorsRedux</RootNamespace>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <Version>2.1.7</Version>
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\PyTK\PyTK.csproj">
-      <Private>false</Private>
-    </ProjectReference>
+    <ProjectReference Include="..\PyTK\PyTK.csproj" Private="false" />
   </ItemGroup>
 
   <Import Project="$(SolutionDir)\common.targets" />

--- a/GhostTown/GhostTown.csproj
+++ b/GhostTown/GhostTown.csproj
@@ -3,12 +3,12 @@
   <PropertyGroup>
     <AssemblyName>GhostTown</AssemblyName>
     <RootNamespace>GhostTown</RootNamespace>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <Version>1.0.4</Version>
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\PyTK\PyTK.csproj" />
+    <ProjectReference Include="..\PyTK\PyTK.csproj" Private="false" />
   </ItemGroup>
 
   <Import Project="$(SolutionDir)\common.targets" />

--- a/HarpOfYobaRedux/HarpOfYobaRedux.csproj
+++ b/HarpOfYobaRedux/HarpOfYobaRedux.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyName>HarpOfYobaRedux</AssemblyName>
     <RootNamespace>HarpOfYobaRedux</RootNamespace>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <Version>2.7.3</Version>
   </PropertyGroup>
 
@@ -12,9 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\PyTK\PyTK.csproj">
-      <Private>false</Private>
-    </ProjectReference>
+    <ProjectReference Include="..\PyTK\PyTK.csproj" Private="false" />
   </ItemGroup>
 
   <Import Project="$(SolutionDir)\common.targets" />

--- a/JoJaBan/JoJaBan.csproj
+++ b/JoJaBan/JoJaBan.csproj
@@ -3,14 +3,12 @@
   <PropertyGroup>
     <AssemblyName>JoJaBan</AssemblyName>
     <RootNamespace>JoJaBan</RootNamespace>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <Version>0.5.0</Version>
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\PyTK\PyTK.csproj">
-      <Private>false</Private>
-    </ProjectReference>
+    <ProjectReference Include="..\PyTK\PyTK.csproj" Private="false" />
   </ItemGroup>
 
   <Import Project="$(SolutionDir)\common.targets" />

--- a/ModUpdater/ModUpdater.csproj
+++ b/ModUpdater/ModUpdater.csproj
@@ -3,10 +3,11 @@
   <PropertyGroup>
     <AssemblyName>ModUpdater</AssemblyName>
     <RootNamespace>ModUpdater</RootNamespace>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <Version>1.1.0</Version>
 
     <EnableHarmony>true</EnableHarmony>
+    <BundleExtraAssemblies>ThirdParty</BundleExtraAssemblies>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ModUpdater/ModUpdater.csproj
+++ b/ModUpdater/ModUpdater.csproj
@@ -5,6 +5,8 @@
     <RootNamespace>ModUpdater</RootNamespace>
     <TargetFramework>net462</TargetFramework>
     <Version>1.1.0</Version>
+
+    <EnableHarmony>true</EnableHarmony>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ModUpdater/ModUpdaterMod.cs
+++ b/ModUpdater/ModUpdaterMod.cs
@@ -1,4 +1,5 @@
-﻿using StardewModdingAPI;
+﻿using HarmonyLib;
+using StardewModdingAPI;
 using System;
 using System.Diagnostics;
 using System.IO;
@@ -264,15 +265,15 @@ namespace ModUpdater
 
         public static void patchModLoad()
         {
-            Harmony.HarmonyInstance harmony = Harmony.HarmonyInstance.Create("Platonymous.ModUpdater");
+            Harmony harmony = new Harmony("Platonymous.ModUpdater");
             harmony.Patch(
                 original:Type.GetType("StardewModdingAPI.Framework.SCore, StardewModdingAPI").GetMethod("CheckForUpdatesAsync", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance),
-                prefix: new Harmony.HarmonyMethod(Harmony.AccessTools.DeclaredMethod(typeof(ModUpdaterMod),nameof(CheckForUpdatesAsync)))
+                prefix: new HarmonyMethod(AccessTools.DeclaredMethod(typeof(ModUpdaterMod),nameof(CheckForUpdatesAsync)))
                 );
 
             harmony.Patch(
                 original: Type.GetType("StardewModdingAPI.Framework.SCore, StardewModdingAPI").GetMethod("TryLoadMod", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance),
-                prefix: new Harmony.HarmonyMethod(Harmony.AccessTools.DeclaredMethod(typeof(ModUpdaterMod), nameof(TryLoadMod)))
+                prefix: new HarmonyMethod(AccessTools.DeclaredMethod(typeof(ModUpdaterMod), nameof(TryLoadMod)))
                 );
         }
         

--- a/NoSoilDecayRedux/NoSoilDecayRedux.csproj
+++ b/NoSoilDecayRedux/NoSoilDecayRedux.csproj
@@ -4,7 +4,7 @@
     <AssemblyName>NoSoilDecayRedux</AssemblyName>
     <RootNamespace>NoSoilDecayRedux</RootNamespace>
     <Version>1.5.7</Version>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <Import Project="$(SolutionDir)\common.targets" />

--- a/Notes/Notes.csproj
+++ b/Notes/Notes.csproj
@@ -4,13 +4,11 @@
     <AssemblyName>Notes</AssemblyName>
     <RootNamespace>Notes</RootNamespace>
     <Version>1.1.0</Version>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\PyTK\PyTK.csproj">
-      <Private>false</Private>
-    </ProjectReference>
+    <ProjectReference Include="..\PyTK\PyTK.csproj" Private="false" />
   </ItemGroup>
 
   <Import Project="$(SolutionDir)\common.targets" />

--- a/PelicanTTS/PelicanTTS.csproj
+++ b/PelicanTTS/PelicanTTS.csproj
@@ -4,7 +4,9 @@
     <AssemblyName>PelicanTTS</AssemblyName>
     <RootNamespace>PelicanTTS</RootNamespace>
     <Version>1.12.6</Version>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
+
+    <BundleExtraAssemblies>ThirdParty</BundleExtraAssemblies>
   </PropertyGroup>
 
   <Import Project="$(SolutionDir)\common.targets" />
@@ -14,6 +16,5 @@
     <PackageReference Include="AWSSDK.Polly" Version="3.7.0.9" />
     <PackageReference Include="Platonymous.Ogg2XNA" Version="1.1.0" />
   </ItemGroup>
-  
 
 </Project>

--- a/PelicanTTS/PelicanTTSMod.cs
+++ b/PelicanTTS/PelicanTTSMod.cs
@@ -5,7 +5,7 @@ using StardewValley;
 using System.IO;
 using System.Collections.Generic;
 using Microsoft.Xna.Framework.Input;
-using Harmony;
+using HarmonyLib;
 using System.Linq;
 using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework;
@@ -199,7 +199,7 @@ namespace PelicanTTS
         public void setUpConfig()
         {
 
-            HarmonyInstance instance = HarmonyInstance.Create("PelicanTTS.GMCM");
+            Harmony instance = new Harmony("PelicanTTS.GMCM");
            // instance.Patch(typeof(ChatBox).GetMethod("receiveChatMessage"), prefix: new HarmonyMethod(typeof(PelicanTTSMod).GetMethod("receiveChatMessage")));
 
             if (!Helper.ModRegistry.IsLoaded("spacechase0.GenericModConfigMenu"))

--- a/PelicanTTS/Screengraber.cs
+++ b/PelicanTTS/Screengraber.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
-using Harmony;
+using HarmonyLib;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using StardewModdingAPI;
@@ -16,7 +16,7 @@ namespace PelicanTTS
 {
     internal class Screengraber
     {
-        HarmonyInstance instance;
+        Harmony instance;
         static bool shouldRead = false;
         static Point target = Point.Zero;
         static string capture = "";
@@ -26,7 +26,7 @@ namespace PelicanTTS
 
         public Screengraber()
         {
-            instance = HarmonyInstance.Create("PelicanTTS.Screengrabber");
+            instance = new Harmony("PelicanTTS.Screengrabber");
             foreach (MethodInfo drawMethod in typeof(SpriteBatch).GetMethods().Where(m => m.GetParameters().Any(p => p.ParameterType == typeof(string) && p.Name == "text")))
                 if (drawMethod.GetParameters().FirstOrDefault(p => p.Name == "scale") is ParameterInfo pa)
                     if (pa.ParameterType == typeof(Vector2))

--- a/PlanImporter/PlanImporter.csproj
+++ b/PlanImporter/PlanImporter.csproj
@@ -4,7 +4,7 @@
     <AssemblyName>PlanImporter</AssemblyName>
     <RootNamespace>PlanImporter</RootNamespace>
     <Version>0.8.12</Version>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -12,15 +12,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="imports\farm.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Include="imports\hill.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
+    <None Include="imports\*" CopyToOutputDirectory="Always" />
   </ItemGroup>
 
   <Import Project="$(SolutionDir)\common.targets" />
 
 </Project>
-

--- a/PlatoWarpMenu/PlatoWarpMenu.csproj
+++ b/PlatoWarpMenu/PlatoWarpMenu.csproj
@@ -4,38 +4,18 @@
     <AssemblyName>PlatoWarpMenu</AssemblyName>
     <RootNamespace>PlatoWarpMenu</RootNamespace>
     <Version>1.9.1</Version>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
    <ItemGroup>
-    <Reference Include="Platonymous.PlatoTK">
-      <HintPath>$(GamePath)\Mods\PlatoTK\PlatoTK.dll</HintPath>
-      <Private>False</Private>
-      <SpecificVersion>false</SpecificVersion>
-    </Reference>
+    <Reference Include="Platonymous.PlatoTK" HintPath="$(GamePath)\Mods\PlatoTK\PlatoTK.dll" Private="False" />
   </ItemGroup>
 
-
   <ItemGroup>
-    <None Update="fonts\escrita.fnt">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="fonts\escrita_0.png">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="fonts\opensans.fnt">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="fonts\opensans_0.png">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="menu.xml">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
+    <None Update="fonts\*" CopyToOutputDirectory="Always" />
+    <None Update="menu.xml" CopyToOutputDirectory="Always" />
   </ItemGroup>
   
   <Import Project="$(SolutionDir)\common.targets" />
   
-  <ProjectExtensions><VisualStudio><UserProperties manifest_1json__JsonSchema="" /></VisualStudio></ProjectExtensions>
-
 </Project>

--- a/PlatoWarpMenu/PlatoWarpMenuMod.cs
+++ b/PlatoWarpMenu/PlatoWarpMenuMod.cs
@@ -1,4 +1,4 @@
-﻿using Harmony;
+﻿using HarmonyLib;
 using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;
 using StardewModdingAPI;
@@ -67,7 +67,7 @@ namespace PlatoWarpMenu
                     pytk = pApi;
             };
 
-            var harmony = HarmonyInstance.Create("Platonymous.PlatoWarpMenu");
+            var harmony = new Harmony("Platonymous.PlatoWarpMenu");
             bool patched = false;
 
             if (!config.CompatibilityMode || Constants.TargetPlatform == GamePlatform.Android)

--- a/PlatoWarpMenu/ScreenshotAndroidFix.cs
+++ b/PlatoWarpMenu/ScreenshotAndroidFix.cs
@@ -290,8 +290,8 @@ namespace PlatoWarpMenu
                                 Game1.spriteBatch.End();
                                 tthis.GraphicsDevice.SetRenderTarget(target_screen);
                             }
-                            if (Game1.bloomDay && Game1.bloom != null)
-                                Game1.bloom.BeginDraw();
+                            //if (Game1.bloomDay && Game1.bloom != null)
+                            //    Game1.bloom.BeginDraw();
                             tthis.GraphicsDevice.Clear(bgColor);
                             Game1.spriteBatch.Begin(SpriteSortMode.Deferred, BlendState.AlphaBlend, SamplerState.PointClamp, (DepthStencilState)null, (RasterizerState)null);
                             if (Game1.background != null)

--- a/Portraiture/PortraitsFix.cs
+++ b/Portraiture/PortraitsFix.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Reflection;
-using Harmony;
+using HarmonyLib;
 using Microsoft.Xna.Framework.Graphics;
 using PyTK.Types;
 using StardewValley;

--- a/Portraiture/Portraiture.csproj
+++ b/Portraiture/Portraiture.csproj
@@ -4,7 +4,7 @@
     <AssemblyName>Portraiture</AssemblyName>
     <RootNamespace>Portraiture</RootNamespace>
     <Version>1.8.2</Version>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -12,13 +12,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Content Include="Portraits\Non-Content-Pack-Folders-Go-Here.txt">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
+    <Content Include="Portraits\Non-Content-Pack-Folders-Go-Here.txt" CopyToOutputDirectory="Always" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\PyTK\PyTK.csproj" />
+    <ProjectReference Include="..\PyTK\PyTK.csproj" Private="false" />
   </ItemGroup>
 
   <Import Project="$(SolutionDir)\common.targets" />

--- a/Portraiture/PortraitureMod.cs
+++ b/Portraiture/PortraitureMod.cs
@@ -1,4 +1,4 @@
-﻿using Harmony;
+﻿using HarmonyLib;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using StardewModdingAPI;
@@ -40,7 +40,7 @@ namespace Portraiture
         }
           private void harmonyFix()
         {
-            HarmonyInstance instance = HarmonyInstance.Create("Platonymous.Portraiture");
+            Harmony instance = new Harmony("Platonymous.Portraiture");
             instance.PatchAll(Assembly.GetExecutingAssembly());
         }
 

--- a/PyTK/CustomElementHandler/SaveHandler.cs
+++ b/PyTK/CustomElementHandler/SaveHandler.cs
@@ -1,4 +1,4 @@
-﻿using Harmony;
+﻿using HarmonyLib;
 using Microsoft.Xna.Framework;
 using Netcode;
 using PyTK.Extensions;
@@ -66,7 +66,7 @@ namespace PyTK.CustomElementHandler
                 Game1.bigCraftableSpriteSheet.Tag = "cod_objects";
             };
 
-            HarmonyInstance instance = HarmonyInstance.Create("PytK.Savehandler.SyncFix");
+            Harmony instance = new Harmony("PytK.Savehandler.SyncFix");
         }
 
         public static bool isRebuildable(object o)

--- a/PyTK/Extensions/PyAssets.cs
+++ b/PyTK/Extensions/PyAssets.cs
@@ -6,6 +6,7 @@ using StardewModdingAPI;
 using StardewValley;
 using xTile;
 using Microsoft.Xna.Framework;
+using Range = PyTK.Types.Range;
 
 namespace PyTK.Extensions
 {

--- a/PyTK/Extensions/PyHarmony.cs
+++ b/PyTK/Extensions/PyHarmony.cs
@@ -1,4 +1,4 @@
-﻿using Harmony;
+﻿using HarmonyLib;
 using StardewModdingAPI;
 using System;
 using System.Collections.Generic;
@@ -12,7 +12,7 @@ namespace PyTK.Extensions
         internal static IModHelper Helper { get; } = PyTKMod._helper;
         internal static IMonitor Monitor { get; } = PyTKMod._monitor;
 
-        private static Dictionary<string, HarmonyInstance> harmonyInstances = new Dictionary<string, HarmonyInstance>();
+        private static Dictionary<string, Harmony> harmonyInstances = new Dictionary<string, Harmony>();
 
         public static void PatchBase(this Type type, IModHelper helper)
         {
@@ -32,9 +32,9 @@ namespace PyTK.Extensions
         public static void PatchType(this Type type, Type typeToPatch, string harmonyId)
         {
             if (!harmonyInstances.ContainsKey(harmonyId))
-                harmonyInstances.Add(harmonyId, HarmonyInstance.Create(harmonyId));
+                harmonyInstances.Add(harmonyId, new Harmony(harmonyId));
 
-            HarmonyInstance harmony = harmonyInstances[harmonyId];
+            Harmony harmony = harmonyInstances[harmonyId];
 
             List<MethodInfo> originals = typeToPatch.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static).Where(m => m != m.GetBaseDefinition()).ToList();
             foreach (MethodInfo method in originals)

--- a/PyTK/Overrides/OvGame.cs
+++ b/PyTK/Overrides/OvGame.cs
@@ -1,4 +1,4 @@
-﻿using Harmony;
+﻿using HarmonyLib;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using PyTK.Extensions;

--- a/PyTK/Overrides/OvLocations.cs
+++ b/PyTK/Overrides/OvLocations.cs
@@ -1,4 +1,4 @@
-﻿using Harmony;
+﻿using HarmonyLib;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using PyTK.ConsoleCommands;

--- a/PyTK/Overrides/OvLongevity.cs
+++ b/PyTK/Overrides/OvLongevity.cs
@@ -1,4 +1,4 @@
-﻿using Harmony;
+﻿using HarmonyLib;
 using PyTK.CustomElementHandler;
 using StardewValley;
 using StardewValley.Objects;

--- a/PyTK/Overrides/OvServer.cs
+++ b/PyTK/Overrides/OvServer.cs
@@ -1,4 +1,4 @@
-﻿using Harmony;
+﻿using HarmonyLib;
 using PyTK.CustomElementHandler;
 using StardewValley.Network;
 using System.Reflection;

--- a/PyTK/Overrides/OvSleep.cs
+++ b/PyTK/Overrides/OvSleep.cs
@@ -1,4 +1,4 @@
-﻿using Harmony;
+﻿using HarmonyLib;
 using PyTK.Events;
 using PyTK.Types;
 using StardewValley;

--- a/PyTK/Overrides/OvSpritebatch.cs
+++ b/PyTK/Overrides/OvSpritebatch.cs
@@ -1,4 +1,4 @@
-﻿using Harmony;
+﻿using HarmonyLib;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using PyTK.CustomElementHandler;

--- a/PyTK/Overrides/OvSpritebatchNew.cs
+++ b/PyTK/Overrides/OvSpritebatchNew.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using HarmonyLib;
 
 namespace PyTK.Overrides
 {
@@ -18,10 +19,10 @@ namespace PyTK.Overrides
 
         internal static bool skip = false;
 
-        internal static void initializePatch(Harmony.HarmonyInstance instance)
+        internal static void initializePatch(Harmony instance)
         {
             foreach (MethodInfo method in typeof(OvSpritebatchNew).GetMethods(BindingFlags.Static | BindingFlags.Public).Where(m => m.Name == "Draw"))
-                instance.Patch(typeof(SpriteBatch).GetMethod("Draw", method.GetParameters().Select(p => p.ParameterType).Where(t => !t.Name.Contains("SpriteBatch")).ToArray()), new Harmony.HarmonyMethod(method), null, null);
+                instance.Patch(typeof(SpriteBatch).GetMethod("Draw", method.GetParameters().Select(p => p.ParameterType).Where(t => !t.Name.Contains("SpriteBatch")).ToArray()), new HarmonyMethod(method), null, null);
         }
 
         internal static CustomObjectData getDataFromSourceRectangle(Rectangle source)

--- a/PyTK/Overrides/OvTV.cs
+++ b/PyTK/Overrides/OvTV.cs
@@ -1,4 +1,4 @@
-﻿using Harmony;
+﻿using HarmonyLib;
 using StardewValley.Objects;
 using System.Reflection;
 using SFarmer = StardewValley.Farmer;

--- a/PyTK/PyTK.csproj
+++ b/PyTK/PyTK.csproj
@@ -4,32 +4,24 @@
     <AssemblyName>PyTK</AssemblyName>
     <RootNamespace>PyTK</RootNamespace>
     <Version>1.22.8</Version>
-    <TargetFramework>net452</TargetFramework>
-    
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-
-    <Authors>Platonymous</Authors>
-
-    <Description>Modding Toolkit for Stardew Valley</Description>
-
-    <Copyright>Copyright 2019</Copyright>
-
-    <PackageProjectUrl>https://github.com/Platonymous/Stardew-Valley-Mods/blob/master/PyTK/Examples.md</PackageProjectUrl>
-
-    <PackageIcon>pytk-icon.png</PackageIcon>
-
-    <RepositoryUrl>https://github.com/Platonymous/Stardew-Valley-Mods/</RepositoryUrl>
-
-    <RepositoryType>GitHub</RepositoryType>
-
-    <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
-
-    <PackageId>Platonymous.PyTK</PackageId>
-
-    <Product>Platonymous.PyTK</Product>
+    <TargetFramework>net5.0</TargetFramework>
 
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Optimize>true</Optimize>
+
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <Authors>Platonymous</Authors>
+    <Description>Modding Toolkit for Stardew Valley</Description>
+    <Copyright>Copyright 2019</Copyright>
+    <PackageProjectUrl>https://github.com/Platonymous/Stardew-Valley-Mods/blob/master/PyTK/Examples.md</PackageProjectUrl>
+    <PackageIcon>pytk-icon.png</PackageIcon>
+    <RepositoryUrl>https://github.com/Platonymous/Stardew-Valley-Mods/</RepositoryUrl>
+    <RepositoryType>GitHub</RepositoryType>
+    <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
+    <PackageId>Platonymous.PyTK</PackageId>
+    <Product>Platonymous.PyTK</Product>
+
+    <BundleExtraAssemblies>ThirdParty</BundleExtraAssemblies>
   </PropertyGroup>
 
   <ItemGroup>
@@ -39,27 +31,13 @@
   </ItemGroup>
   
   <ItemGroup>
-  <Reference Include="TMXTile">
-    <HintPath>$(GamePath)\smapi-internal\TMXTile.dll</HintPath>
-    <Private>False</Private>
-    <SpecificVersion>false</SpecificVersion>
-  </Reference>
-    <Reference Include="BmFont">
-      <HintPath>$(GamePath)\BmFont.dll</HintPath>
-      <Private>true</Private>
-      <SpecificVersion>false</SpecificVersion>
-    </Reference>
+  <Reference Include="TMXTile" HintPath="$(GamePath)\smapi-internal\TMXTile.dll" Private="False" />
+    <Reference Include="BmFont" HintPath="$(GamePath)\BmFont.dll" Private="False" />
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="LICENSE.txt">
-      <Pack>True</Pack>
-      <PackagePath></PackagePath>
-    </None>
-    <None Include="pytk-icon.png">
-      <Pack>True</Pack>
-      <PackagePath></PackagePath>
-    </None>
+    <None Include="LICENSE.txt" Pack="True" PackagePath="" />
+    <None Include="pytk-icon.png" Pack="True" PackagePath="" />
   </ItemGroup>
 
   <Import Project="$(SolutionDir)\common.targets" />

--- a/PyTK/PyTKMod.cs
+++ b/PyTK/PyTKMod.cs
@@ -690,12 +690,12 @@ namespace PyTK
 
             foreach (var serializer in serializers)
             {
-                var cache = serializer.GetType().GetField("cache", BindingFlags.NonPublic | BindingFlags.Static).GetValue(null);
-                Hashtable cacheTable = (Hashtable)cache.GetType().GetField("cache", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(cache);
+                var cache = serializer.GetType().GetField("s_cache", BindingFlags.NonPublic | BindingFlags.Static).GetValue(null);
+                IDictionary cacheTable = (IDictionary)cache.GetType().GetField("_cache", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(cache);
 
                 foreach (var c in cacheTable.Values)
                 {
-                    var a = (Assembly)c.GetType().GetField("assembly", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(c);
+                    var a = (Assembly)c.GetType().GetField("_assembly", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(c);
                     PatchGeneratedSerializers(new Assembly[] { a });
                 }
 
@@ -705,7 +705,7 @@ namespace PyTK
 
         public static void AssemblyCachePatch(string ns, object o, object assembly)
         {
-            PatchGeneratedSerializers(new Assembly[] { (Assembly)assembly.GetType().GetField("assembly", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(assembly) });
+            PatchGeneratedSerializers(new Assembly[] { (Assembly)assembly.GetType().GetField("_assembly", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(assembly) });
         }
 
         public static void serializeFix(ref System.Object o)
@@ -761,12 +761,12 @@ namespace PyTK
 
             if (ty.FullName.Contains("XmlSerializer1"))
             {
-                if (Constants.TargetPlatform != GamePlatform.Android && ty.GetField("cache", BindingFlags.NonPublic | BindingFlags.Static) is FieldInfo field && field.GetValue(null) is object cache)
-                    if (cache.GetType().GetField("cache", BindingFlags.NonPublic | BindingFlags.Instance) is FieldInfo cField && cField.GetValue(cache) is Hashtable cacheTable)
+                if (Constants.TargetPlatform != GamePlatform.Android && ty.BaseType.GetField("s_cache", BindingFlags.NonPublic | BindingFlags.Static) is FieldInfo field && field.GetValue(null) is object cache)
+                    if (cache.GetType().GetField("_cache", BindingFlags.NonPublic | BindingFlags.Instance) is FieldInfo cField && cField.GetValue(cache) is IDictionary cacheTable)
                     {
                         foreach (var c in cacheTable.Values)
                         {
-                            var a = (Assembly)c.GetType().GetField("assembly", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(c);
+                            var a = (Assembly)c.GetType().GetField("_assembly", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(c);
                             PatchGeneratedSerializers(new Assembly[] { a });
                         }
 

--- a/PyTK/PyTKMod.cs
+++ b/PyTK/PyTKMod.cs
@@ -8,7 +8,7 @@ using PyTK.Types;
 using PyTK.CustomElementHandler;
 using PyTK.ConsoleCommands;
 using PyTK.CustomTV;
-using Harmony;
+using HarmonyLib;
 using System.Reflection;
 using StardewValley.Menus;
 using System.Collections.Generic;
@@ -58,7 +58,7 @@ namespace PyTK
         internal static object waitForPatching = new object();
         internal static object waitForItems = new object();
 
-        internal static HarmonyInstance hInstance;
+        internal static Harmony hInstance;
 
         internal static UpdateTickedEventArgs updateTicked;
 
@@ -92,7 +92,7 @@ namespace PyTK
                 Config = new PyTKConfig();
                 helper.WriteConfig(Config);
             }
-            hInstance = HarmonyInstance.Create("Platonymous.PyTK.Rev");
+            hInstance = new Harmony("Platonymous.PyTK.Rev");
             helper.Events.Display.RenderingWorld += (s,e) =>
             {
                 if (Game1.currentLocation is GameLocation location && location.Map is Map map && map.GetBackgroundColor() is TMXColor tmxColor)
@@ -375,7 +375,7 @@ namespace PyTK
                 TileAction.invokeCustomTileActions("EntryAction", g, Vector2.Zero, "Map");
         }
         
-        public static HarmonyInstance instance = HarmonyInstance.Create("Platonymous.PyTK");
+        public static Harmony instance = new Harmony("Platonymous.PyTK");
 
         private void harmonyFix()
         {
@@ -424,7 +424,7 @@ namespace PyTK
             setupLoadIntercepter(instance);
         }
        
-        private void setupLoadIntercepter(HarmonyInstance harmony)
+        private void setupLoadIntercepter(Harmony harmony)
         {
              Monitor.Log("Patching: FromStream", LogLevel.Trace);
 
@@ -683,7 +683,7 @@ namespace PyTK
             }
         }
 
-        public void SetUpAssemblyPatch(HarmonyInstance instance, IEnumerable<XmlSerializer> serializers)
+        public void SetUpAssemblyPatch(Harmony instance, IEnumerable<XmlSerializer> serializers)
         {
             if (Config.Options.Contains("DisableSerializerPatch"))
                 return;

--- a/PyTK/PyUtils.cs
+++ b/PyTK/PyUtils.cs
@@ -11,7 +11,7 @@ using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using System.Collections;
 using NCalc;
-using Harmony;
+using HarmonyLib;
 using System.Reflection;
 using PyTK.Lua;
 using PyTK.Extensions;
@@ -382,7 +382,7 @@ namespace PyTK
 
         public static void initOverride(string harmonyId, Type type, Type patch, List<string> toPatch)
         {
-            HarmonyInstance harmony = HarmonyInstance.Create("Platonymous.PyTK.PyUtils." + harmonyId);
+            Harmony harmony = new Harmony("Platonymous.PyTK.PyUtils." + harmonyId);
             MethodInfo prefix = patch.GetMethods(BindingFlags.Static | BindingFlags.Public).ToList().Find(m => m.Name.ToLower() == "prefix");
             MethodInfo postfix = patch.GetMethods(BindingFlags.Static | BindingFlags.Public).ToList().Find(m => m.Name.ToLower() == "postfix");
             List<MethodInfo> originals = type.GetMethods().ToList();

--- a/SeedBag/SeedBag.csproj
+++ b/SeedBag/SeedBag.csproj
@@ -4,15 +4,11 @@
     <AssemblyName>SeedBag</AssemblyName>
     <RootNamespace>SeedBag</RootNamespace>
     <Version>1.7.4</Version>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Platonymous.PlatoTK">
-      <HintPath>$(GamePath)\Mods\PlatoTK\PlatoTK.dll</HintPath>
-      <Private>False</Private>
-      <SpecificVersion>false</SpecificVersion>
-    </Reference>
+    <Reference Include="Platonymous.PlatoTK" HintPath="$(GamePath)\Mods\PlatoTK\PlatoTK.dll" Private="False" />
   </ItemGroup>
 
   <Import Project="$(SolutionDir)\common.targets" />

--- a/ShipFromInventory/ShipFromInventory.csproj
+++ b/ShipFromInventory/ShipFromInventory.csproj
@@ -4,7 +4,7 @@
     <AssemblyName>ShipFromInventory</AssemblyName>
     <RootNamespace>ShipFromInventory</RootNamespace>
     <Version>1.4.1</Version>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <Import Project="$(SolutionDir)\common.targets" />

--- a/ShipFromInventory/ShipFromInventoryMod.cs
+++ b/ShipFromInventory/ShipFromInventoryMod.cs
@@ -1,4 +1,4 @@
-﻿using Harmony;
+﻿using HarmonyLib;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using StardewModdingAPI;
@@ -33,7 +33,7 @@ namespace ShipFromInventory
             config = helper.ReadConfig<Config>();
             shippingBinTexture = helper.Content.Load<Texture2D>(@"Buildings/Shipping Bin", ContentSource.GameContent);
             shippingBinLidRectangle = new Rectangle(134, 226, 30, 25);
-            var instance = HarmonyInstance.Create("Platonymous.ShipFromInventory");
+            var instance = new Harmony("Platonymous.ShipFromInventory");
             instance.Patch(typeof(InventoryPage).GetConstructor(new[] { typeof(int), typeof(int), typeof(int), typeof(int) }), null, new HarmonyMethod(this.GetType().GetMethod("InventoryPageCon")));
             instance.Patch(typeof(InventoryPage).GetMethod("draw", new[] { typeof(SpriteBatch) }), null, new HarmonyMethod(this.GetType().GetMethod("InventoryPageDraw")));
             if (Type.GetType("BiggerBackpack.NewInventoryPage, BiggerBackpack") is Type bbpType)

--- a/SleepWorker/SleepWorker.csproj
+++ b/SleepWorker/SleepWorker.csproj
@@ -4,13 +4,11 @@
     <AssemblyName>SleepWorker</AssemblyName>
     <RootNamespace>SleepWorker</RootNamespace>
     <Version>1.2.3</Version>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\PyTK\PyTK.csproj">
-      <Private>false</Private>
-    </ProjectReference>
+    <ProjectReference Include="..\PyTK\PyTK.csproj" Private="false" />
   </ItemGroup>
 
   <Import Project="$(SolutionDir)\common.targets" />

--- a/SnakeArcadeMachine/SnakeArcadeMachine.csproj
+++ b/SnakeArcadeMachine/SnakeArcadeMachine.csproj
@@ -4,7 +4,7 @@
     <AssemblyName>SnakeArcadeMachine</AssemblyName>
     <RootNamespace>SnakeArcadeMachine</RootNamespace>
     <Version>1.0.0</Version>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <ModFolderName>[JA] ArcadeSnake</ModFolderName>
   </PropertyGroup>
   

--- a/TMXLoader/Overrides.cs
+++ b/TMXLoader/Overrides.cs
@@ -1,4 +1,4 @@
-﻿using Harmony;
+﻿using HarmonyLib;
 using StardewValley;
 using StardewValley.Locations;
 using System;

--- a/TMXLoader/TMXActions.cs
+++ b/TMXLoader/TMXActions.cs
@@ -16,6 +16,7 @@ using xTile;
 using xTile.Dimensions;
 using xTile.Layers;
 using xTile.Tiles;
+using Range = PyTK.Types.Range;
 
 namespace TMXLoader
 {

--- a/TMXLoader/TMXLoader.csproj
+++ b/TMXLoader/TMXLoader.csproj
@@ -4,26 +4,19 @@
     <AssemblyName>TMXLoader</AssemblyName>
     <RootNamespace>TMXLoader</RootNamespace>
     <Version>1.22.1</Version>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="sr.lua">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
+    <None Include="sr.lua" CopyToOutputDirectory="Always" />
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="TMXTile">
-      <HintPath>$(GamePath)\smapi-internal\TMXTile.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
+    <Reference Include="TMXTile" HintPath="$(GamePath)\smapi-internal\TMXTile.dll" Private="False" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\PyTK\PyTK.csproj">
-      <Private>false</Private>
-    </ProjectReference>
+    <ProjectReference Include="..\PyTK\PyTK.csproj" Private="false" />
   </ItemGroup>
 
   <Import Project="$(SolutionDir)\common.targets" />

--- a/TMXLoader/TMXLoaderMod.cs
+++ b/TMXLoader/TMXLoaderMod.cs
@@ -10,7 +10,7 @@ using StardewValley;
 using System.Collections.Generic;
 using System.IO;
 using xTile;
-using Harmony;
+using HarmonyLib;
 using System.Reflection;
 using System.Linq;
 using Microsoft.Xna.Framework.Graphics;
@@ -1134,7 +1134,7 @@ namespace TMXLoader
 
         private void harmonyFix()
         {
-            HarmonyInstance instance = HarmonyInstance.Create("Platonymous.TMXLoader");
+            Harmony instance = new Harmony("Platonymous.TMXLoader");
             instance.PatchAll(Assembly.GetExecutingAssembly());
             instance.Patch(typeof(SaveGame).GetMethod("loadDataToLocations"), postfix: new HarmonyMethod(this.GetType().GetMethod("SavePatch", BindingFlags.Public | BindingFlags.Static)));
             instance.Patch(typeof(GameLocation).GetMethod("setMapTile"), prefix: new HarmonyMethod(this.GetType().GetMethod("trySetMapTile", BindingFlags.Public | BindingFlags.Static)));

--- a/TMX_BusPeople/TMX_BusPeople.csproj
+++ b/TMX_BusPeople/TMX_BusPeople.csproj
@@ -4,11 +4,10 @@
     <AssemblyName>TMX_BusPeople</AssemblyName>
     <RootNamespace>TMX_BusPeople</RootNamespace>
     <Version>1.3.0</Version>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <ModFolderName>[TMX]JungleTempleAndCityBus</ModFolderName>
   </PropertyGroup>
 
- 
   <Import Project="$(SolutionDir)\contentpacks.targets" />
 
 </Project>

--- a/Visualize/SpritebatchFixNew.cs
+++ b/Visualize/SpritebatchFixNew.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Xna.Framework;
+﻿using HarmonyLib;
+using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using System;
 using System.Linq;
@@ -10,13 +11,13 @@ namespace Visualize
     class SpritbatchFixNew
     {
 
-        internal static void initializePatch(Harmony.HarmonyInstance instance)
+        internal static void initializePatch(Harmony instance)
         {
             foreach (MethodInfo method in typeof(SpritbatchFixNew).GetMethods(BindingFlags.Static | BindingFlags.Public).Where(m => m.Name == "Draw"))
             {
                 try
                 {
-                    instance.Patch(typeof(SpriteBatch).GetMethod("Draw", method.GetParameters().Select(p => p.ParameterType.Name.Contains("Texture2D") ? typeof(Texture2D) : p.ParameterType.Name.Contains("Color") ? typeof(Color) : p.ParameterType).Where(t => !t.Name.Contains("SpriteBatch")).ToArray()), new Harmony.HarmonyMethod(method), null, null);
+                    instance.Patch(typeof(SpriteBatch).GetMethod("Draw", method.GetParameters().Select(p => p.ParameterType.Name.Contains("Texture2D") ? typeof(Texture2D) : p.ParameterType.Name.Contains("Color") ? typeof(Color) : p.ParameterType).Where(t => !t.Name.Contains("SpriteBatch")).ToArray()), new HarmonyMethod(method), null, null);
                 }
                 catch (Exception e)
                 {
@@ -29,7 +30,7 @@ namespace Visualize
             {
                 try
                 {
-                    instance.Patch(typeof(SpriteBatch).GetMethod("DrawString", method.GetParameters().Select(p => p.ParameterType.Name.Contains("Color") ? typeof(Color) : p.ParameterType).Where(t => !t.Name.Contains("SpriteBatch")).ToArray()), new Harmony.HarmonyMethod(method), null, null);
+                    instance.Patch(typeof(SpriteBatch).GetMethod("DrawString", method.GetParameters().Select(p => p.ParameterType.Name.Contains("Color") ? typeof(Color) : p.ParameterType).Where(t => !t.Name.Contains("SpriteBatch")).ToArray()), new HarmonyMethod(method), null, null);
                 }
                 catch (Exception e)
                 {

--- a/Visualize/Visualize.csproj
+++ b/Visualize/Visualize.csproj
@@ -4,91 +4,12 @@
     <AssemblyName>Visualize</AssemblyName>
     <RootNamespace>Visualize</RootNamespace>
     <Version>1.8.1</Version>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="Profiles\Platonymous.BlackAndWhite.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Include="Profiles\Platonymous.EGA.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Include="Profiles\Platonymous.CGA.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Include="Profiles\Platonymous.C64.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Include="Profiles\Platonymous.Desaturated.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Include="Profiles\Platonymous.Gameboy.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Include="Profiles\Platonymous.GameboyPocket.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Include="Profiles\Platonymous.Greyscale.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Include="Profiles\Platonymous.Genesis.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Include="Profiles\Platonymous.NES-limited.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Include="Profiles\Platonymous.Original.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Include="Profiles\Platonymous.MasterSystem.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Include="Profiles\Platonymous.Pico8.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Include="Profiles\Platonymous.RiscOS16.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Include="Profiles\Platonymous.SepiaPalette.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <Content Include="Profiles\bw.png">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Profiles\c64.png">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Profiles\cga.png">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Profiles\ega.png">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Profiles\gameboy.png">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Profiles\gameboyPaletteFromImage.png">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Profiles\genesispalette.png">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Profiles\mastersystem.png">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Profiles\nes_limited.png">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Profiles\palette_numbers.png">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Profiles\riscOS16.png">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Profiles\sepia.png">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
+    <None Include="Profiles\*.json" CopyToOutputDirectory="Always" />
+    <Content Include="Profiles\*.png" CopyToOutputDirectory="Always" />
   </ItemGroup>
 
   <Import Project="$(SolutionDir)\common.targets" />

--- a/Visualize/VisualizeMod.cs
+++ b/Visualize/VisualizeMod.cs
@@ -1,4 +1,4 @@
-﻿using Harmony;
+﻿using HarmonyLib;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using StardewModdingAPI;
@@ -196,7 +196,7 @@ namespace Visualize
 
         private void harmonyFix()
         {
-            var instance = HarmonyInstance.Create("Platonymous.Visualize");
+            var instance = new Harmony("Platonymous.Visualize");
             instance.PatchAll(Assembly.GetExecutingAssembly());
             SpritbatchFixNew.initializePatch(instance);
         }

--- a/common.targets
+++ b/common.targets
@@ -105,7 +105,7 @@
   </Target>
   -->
   <ItemGroup>
-    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="3.3.0" />
+    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="4.0.0-beta.20210916" />
   </ItemGroup>
   
 

--- a/contentpacks.targets
+++ b/contentpacks.targets
@@ -100,7 +100,7 @@
   </Target>-->
 
   <ItemGroup>
-    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="3.3.0" />
+    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="4.0.0-beta.20210916" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This pull request updates the code for compatibility with the Stardew Valley 1.5.5 beta.

More specifically, this PR...

* updates the target frameworks (the game uses .NET 5 now);
* updates to Harmony 2.1 (needed for .NET 5);
* updates the mod build package;
* updates how the mods bundle extra dependencies for .NET 5;
* updates PyTK's serializer patches for changes in .NET 5 (thanks to @d235j!);
* fixes a naming conflict between PyTK's `Range` and the new `System.Range` type;
* removes references to bloom code (which no longer exists) in Plato Warp Menu.

Note that Platonymous.Ogg2XNA will need to be updated too before Custom Music works with the beta.