### PR TITLE
Fixed HarpOfYoba on Linux/MacOS

### DIFF
--- a/HarpOfYobaRedux/DataLoader.cs
+++ b/HarpOfYobaRedux/DataLoader.cs
@@ -68,7 +68,7 @@ namespace HarpOfYobaRedux
 
         private static Texture2D loadTexture(IModHelper helper, string file)
         {
-            return helper.Content.Load<Texture2D>($"Assets/{file}");
+            return helper.Content.Load<Texture2D>($"assets/{file}");
         }
 
     }


### PR DESCRIPTION
Harp of Yoba would crash on Linux and MacOS due to missing files. It's actually just that unix machines are case sensitive when it comes to filenames. This should fix that.