### PR TITLE
HarpOfYoba needs to be updated for the newer PyTK version

### DIFF
--- a/HarpOfYobaRedux/HarpOfYobaRedux.csproj
+++ b/HarpOfYobaRedux/HarpOfYobaRedux.csproj
@@ -4,7 +4,7 @@
     <AssemblyName>HarpOfYobaRedux</AssemblyName>
     <RootNamespace>HarpOfYobaRedux</RootNamespace>
     <TargetFramework>net5.0</TargetFramework>
-    <Version>2.7.3</Version>
+    <Version>2.7.5</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
2.7.3 is listed as incompatible by SMAPI and will not load, while an unofficial update took the version 2.7.4 and does not work with PyTK 1.23.2.
No code changes seem to be needed.