### PR TITLE
Fix bug with png files that aren't valid

### DIFF
--- a/Portraiture/TextureLoader.cs
+++ b/Portraiture/TextureLoader.cs
@@ -222,8 +222,11 @@ namespace Portraiture
 
 
                     ScaledTexture2D scaled;
-                    
-                        scaled = ScaledTexture2D.FromTexture(Game1.getCharacterFromName(name).Portrait, texture, scale);
+
+                        var npc = Game1.getCharacterFromName(name);
+                        if (npc == null)
+                            continue;
+                        scaled = ScaledTexture2D.FromTexture(npc.Portrait, texture, scale);
                    
                     if (!pTextures.ContainsKey(folderName + ">" + name))
                         pTextures.Add(folderName + ">" + name, scaled);


### PR DESCRIPTION
Fixes a bug where in if a file is in the mod directory and doesn't work with an NPC, it will skip over using that file.
- Update `Portraiture/TextureLoader.cs`